### PR TITLE
Refactoring health loggers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,13 +131,11 @@ spotbugsMain {
         html.enabled = true
     }
 }
-
 spotbugsTest {
     reports {
         html.enabled = true
     }
 }
-
 spotbugs {
     showProgress = true
     excludeFilter = file("config/spotbugs/exclude.xml")

--- a/src/main/java/io/github/mfvanek/pg/common/health/logger/AbstractHealthLogger.java
+++ b/src/main/java/io/github/mfvanek/pg/common/health/logger/AbstractHealthLogger.java
@@ -67,6 +67,8 @@ public abstract class AbstractHealthLogger implements HealthLogger {
                                      @Nonnull final PgContext pgContext) {
         Objects.requireNonNull(exclusions);
         Objects.requireNonNull(pgContext);
+        // The main idea here is to create haPgConnection for a short period of time.
+        // This helps to avoid dealing with failover/switch-over situations that occur in real clusters.
         final HighAvailabilityPgConnection haPgConnection = connectionFactory.of(credentials);
         final DatabaseHealth databaseHealth = databaseHealthFactory.of(haPgConnection);
         final List<String> logResult = new ArrayList<>();

--- a/src/main/java/io/github/mfvanek/pg/common/health/logger/KeyValueFileHealthLogger.java
+++ b/src/main/java/io/github/mfvanek/pg/common/health/logger/KeyValueFileHealthLogger.java
@@ -39,13 +39,13 @@ import javax.annotation.Nonnull;
  *
  * @author Ivan Vakhrushev
  */
-public class SimpleHealthLogger extends AbstractHealthLogger {
+public class KeyValueFileHealthLogger extends AbstractHealthLogger {
 
     private static final Logger KV_LOG = LoggerFactory.getLogger("key-value.log");
 
-    public SimpleHealthLogger(@Nonnull final ConnectionCredentials credentials,
-                              @Nonnull final HighAvailabilityPgConnectionFactory connectionFactory,
-                              @Nonnull final DatabaseHealthFactory databaseHealthFactory) {
+    public KeyValueFileHealthLogger(@Nonnull final ConnectionCredentials credentials,
+                                    @Nonnull final HighAvailabilityPgConnectionFactory connectionFactory,
+                                    @Nonnull final DatabaseHealthFactory databaseHealthFactory) {
         super(credentials, connectionFactory, databaseHealthFactory);
     }
 

--- a/src/main/java/io/github/mfvanek/pg/common/health/logger/StandardHealthLogger.java
+++ b/src/main/java/io/github/mfvanek/pg/common/health/logger/StandardHealthLogger.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019-2022. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - a Java library for
+ * analyzing and maintaining indexes health in PostgreSQL databases.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.common.health.logger;
+
+import io.github.mfvanek.pg.common.health.DatabaseHealthFactory;
+import io.github.mfvanek.pg.connection.ConnectionCredentials;
+import io.github.mfvanek.pg.connection.HighAvailabilityPgConnectionFactory;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Outputs summary about database health to an array of strings.
+ *
+ * @author Ivan Vakhrushev
+ */
+public class StandardHealthLogger extends AbstractHealthLogger {
+
+    public StandardHealthLogger(@Nonnull final ConnectionCredentials credentials,
+                                @Nonnull final HighAvailabilityPgConnectionFactory connectionFactory,
+                                @Nonnull final DatabaseHealthFactory databaseHealthFactory) {
+        super(credentials, connectionFactory, databaseHealthFactory);
+    }
+
+    @Override
+    protected String writeToLog(@Nonnull final LoggingKey key, final int value) {
+        return key.getSubKeyName() + ":" + value;
+    }
+}

--- a/src/main/java/io/github/mfvanek/pg/connection/HighAvailabilityPgConnectionFactoryImpl.java
+++ b/src/main/java/io/github/mfvanek/pg/connection/HighAvailabilityPgConnectionFactoryImpl.java
@@ -12,13 +12,11 @@ package io.github.mfvanek.pg.connection;
 
 import org.apache.commons.lang3.tuple.Pair;
 
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Set;
 import javax.annotation.Nonnull;
 
 public class HighAvailabilityPgConnectionFactoryImpl implements HighAvailabilityPgConnectionFactory {
@@ -42,8 +40,7 @@ public class HighAvailabilityPgConnectionFactoryImpl implements HighAvailability
         credentials.getConnectionUrls().forEach(
                 url -> addDataSourcesForAllHostsFromUrl(connectionsToAllHostsInCluster, url, credentials));
         final PgConnection connectionToPrimary = findConnectionToPrimary(connectionsToAllHostsInCluster);
-        final Set<PgConnection> pgConnections = new HashSet<>(connectionsToAllHostsInCluster.values());
-        return HighAvailabilityPgConnectionImpl.of(connectionToPrimary, pgConnections);
+        return HighAvailabilityPgConnectionImpl.of(connectionToPrimary, connectionsToAllHostsInCluster.values());
     }
 
     private void addDataSourcesForAllHostsFromUrl(@Nonnull final Map<String, PgConnection> connectionsToAllHostsInCluster,

--- a/src/main/java/io/github/mfvanek/pg/connection/HighAvailabilityPgConnectionImpl.java
+++ b/src/main/java/io/github/mfvanek/pg/connection/HighAvailabilityPgConnectionImpl.java
@@ -10,6 +10,7 @@
 
 package io.github.mfvanek.pg.connection;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -18,14 +19,17 @@ import javax.annotation.Nonnull;
 
 public class HighAvailabilityPgConnectionImpl implements HighAvailabilityPgConnection {
 
+    // TODO Bad design. Need logic here to deal with failover/switch-over in real cluster.
+    //  As a possible solution - cache connectionToPrimary for a short period of time (e.g. 1 minute)
     private final PgConnection connectionToPrimary;
     private final Set<PgConnection> connectionsToAllHostsInCluster;
 
     private HighAvailabilityPgConnectionImpl(@Nonnull final PgConnection connectionToPrimary,
-                                             @Nonnull final Set<PgConnection> connectionsToAllHostsInCluster) {
+                                             @Nonnull final Collection<PgConnection> connectionsToAllHostsInCluster) {
         this.connectionToPrimary = Objects.requireNonNull(connectionToPrimary, "connectionToPrimary");
         final Set<PgConnection> defensiveCopy = new HashSet<>(
                 Objects.requireNonNull(connectionsToAllHostsInCluster, "connectionsToAllHostsInCluster"));
+        PgConnectionValidators.shouldContainsConnectionToPrimary(connectionToPrimary, defensiveCopy);
         this.connectionsToAllHostsInCluster = Collections.unmodifiableSet(defensiveCopy);
     }
 
@@ -54,7 +58,7 @@ public class HighAvailabilityPgConnectionImpl implements HighAvailabilityPgConne
 
     @Nonnull
     public static HighAvailabilityPgConnection of(@Nonnull final PgConnection connectionToPrimary,
-                                                  @Nonnull final Set<PgConnection> connectionsToAllHostsInCluster) {
+                                                  @Nonnull final Collection<PgConnection> connectionsToAllHostsInCluster) {
         return new HighAvailabilityPgConnectionImpl(connectionToPrimary, connectionsToAllHostsInCluster);
     }
 }

--- a/src/main/java/io/github/mfvanek/pg/connection/PgConnectionValidators.java
+++ b/src/main/java/io/github/mfvanek/pg/connection/PgConnectionValidators.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nonnull;
 
 final class PgConnectionValidators {
@@ -49,6 +50,13 @@ final class PgConnectionValidators {
             throw new IllegalArgumentException("connectionUrls have to contain at least one url");
         }
         connectionUrls.forEach(url -> pgUrlNotBlankAndValid(url, "connectionUrl"));
+    }
+
+    static void shouldContainsConnectionToPrimary(@Nonnull final PgConnection connectionToPrimary,
+                                                  @Nonnull final Set<PgConnection> connectionsToAllHostsInCluster) {
+        if (!connectionsToAllHostsInCluster.contains(connectionToPrimary)) {
+            throw new IllegalArgumentException("connectionsToAllHostsInCluster have to contain a connection to the primary");
+        }
     }
 
     private static void notBlank(@Nonnull final String argumentValue, @Nonnull final String argumentName) {

--- a/src/test/java/io/github/mfvanek/pg/common/health/logger/HealthLoggerTest.java
+++ b/src/test/java/io/github/mfvanek/pg/common/health/logger/HealthLoggerTest.java
@@ -42,7 +42,7 @@ public final class HealthLoggerTest extends DatabaseAwareTestBase {
         super(embeddedPostgres.getTestDatabase());
         final ConnectionCredentials credentials = ConnectionCredentials.ofUrl(
                 embeddedPostgres.getUrl(), embeddedPostgres.getUsername(), embeddedPostgres.getPassword());
-        this.logger = new SimpleHealthLogger(
+        this.logger = new KeyValueFileHealthLogger(
                 credentials,
                 new HighAvailabilityPgConnectionFactoryImpl(new PgConnectionFactoryImpl(), new PrimaryHostDeterminerImpl()),
                 new DatabaseHealthFactoryImpl(new MaintenanceFactoryImpl()));

--- a/src/test/java/io/github/mfvanek/pg/common/health/logger/KeyValueFileHealthLoggerTest.java
+++ b/src/test/java/io/github/mfvanek/pg/common/health/logger/KeyValueFileHealthLoggerTest.java
@@ -36,13 +36,13 @@ import java.util.List;
 import static io.github.mfvanek.pg.utils.HealthLoggerAssertions.assertContainsKey;
 import static org.mockito.ArgumentMatchers.any;
 
-class SimpleHealthLoggerTest {
+class KeyValueFileHealthLoggerTest {
 
     private final ConnectionCredentials credentials = Mockito.mock(ConnectionCredentials.class);
     private final DatabaseHealth databaseHealth = Mockito.mock(DatabaseHealth.class);
     private final DatabaseHealthFactory databaseHealthFactory = Mockito.mock(DatabaseHealthFactory.class);
     private final HighAvailabilityPgConnectionFactory connectionFactory = Mockito.mock(HighAvailabilityPgConnectionFactory.class);
-    private final HealthLogger logger = new SimpleHealthLogger(credentials, connectionFactory, databaseHealthFactory);
+    private final HealthLogger logger = new KeyValueFileHealthLogger(credentials, connectionFactory, databaseHealthFactory);
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/io/github/mfvanek/pg/common/health/logger/StandardHealthLoggerTest.java
+++ b/src/test/java/io/github/mfvanek/pg/common/health/logger/StandardHealthLoggerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019-2022. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - a Java library for
+ * analyzing and maintaining indexes health in PostgreSQL databases.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.common.health.logger;
+
+import io.github.mfvanek.pg.common.health.DatabaseHealth;
+import io.github.mfvanek.pg.common.health.DatabaseHealthFactory;
+import io.github.mfvanek.pg.connection.ConnectionCredentials;
+import io.github.mfvanek.pg.connection.HighAvailabilityPgConnectionFactory;
+import io.github.mfvanek.pg.model.PgContext;
+import io.github.mfvanek.pg.model.index.Index;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static io.github.mfvanek.pg.utils.HealthLoggerAssertions.assertContainsKey;
+import static org.mockito.ArgumentMatchers.any;
+
+class StandardHealthLoggerTest {
+
+    private final ConnectionCredentials credentials = Mockito.mock(ConnectionCredentials.class);
+    private final DatabaseHealth databaseHealth = Mockito.mock(DatabaseHealth.class);
+    private final DatabaseHealthFactory databaseHealthFactory = Mockito.mock(DatabaseHealthFactory.class);
+    private final HighAvailabilityPgConnectionFactory connectionFactory = Mockito.mock(HighAvailabilityPgConnectionFactory.class);
+    private final HealthLogger logger = new StandardHealthLogger(credentials, connectionFactory, databaseHealthFactory);
+
+    @BeforeEach
+    void setUp() {
+        Mockito.when(databaseHealthFactory.of(any())).thenReturn(databaseHealth);
+    }
+
+    @Test
+    void logInvalidIndexes() {
+        Mockito.when(databaseHealth.getInvalidIndexes(any(PgContext.class)))
+                .thenReturn(Arrays.asList(
+                        Index.of("t1", "i1"),
+                        Index.of("t1", "i2"),
+                        Index.of("t2", "i3")
+                ));
+        final List<String> logs = logger.logAll(Exclusions.empty());
+        assertContainsKey(logs, SimpleLoggingKey.INVALID_INDEXES, "invalid_indexes:3");
+    }
+}


### PR DESCRIPTION
1. Renamed SimpleHealthLogger to KeyValueFileHealthLogger. Breaking changes!
2. Added default and pretty simple StandardHealthLogger
3. Simplified creation of HighAvailabilityPgConnection