### PR TITLE
Parameterization of username\password for cluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ description = 'pg-index-health build'
 
 allprojects {
     group 'io.github.mfvanek'
-    version '0.9.2-SNAPSHOT'
+    version '0.9.1-SNAPSHOT'
 
     repositories {
         mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ description = 'pg-index-health build'
 
 allprojects {
     group 'io.github.mfvanek'
-    version '0.9.1-SNAPSHOT'
+    version '0.9.2-SNAPSHOT'
 
     repositories {
         mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ subprojects {
         slf4jVersion = '2.0.7'
         logbackVersion = '1.4.6'
         dbcp2Version = '2.9.0'
-        testcontainersVersion = '1.17.6'
+        testcontainersVersion = '1.18.0'
         postgresqlVersion = '42.6.0'
         mockitoVersion = '5.2.0'
         awaitilityVersion = '4.2.0'

--- a/pg-index-health-testing/src/main/java/io/github/mfvanek/pg/testing/PostgreSqlClusterAliasHolder.java
+++ b/pg-index-health-testing/src/main/java/io/github/mfvanek/pg/testing/PostgreSqlClusterAliasHolder.java
@@ -88,8 +88,8 @@ final class PostgreSqlClusterAliasHolder {
             @Nonnull final String customUsername,
             @Nonnull final String customPassword
     ) {
-        final String username = Objects.requireNonNull(customUsername, "username mustn't be null");
-        final String password = Objects.requireNonNull(customPassword, "password mustn't be null");
+        final String username = Objects.requireNonNull(customUsername, "username cannot be null");
+        final String password = Objects.requireNonNull(customPassword, "password cannot be null");
 
         final Map<String, String> envVarsMap = new HashMap<>();
         envVarsMap.put("POSTGRESQL_POSTGRES_PASSWORD", "adminpassword");

--- a/pg-index-health-testing/src/main/java/io/github/mfvanek/pg/testing/PostgreSqlClusterAliasHolder.java
+++ b/pg-index-health-testing/src/main/java/io/github/mfvanek/pg/testing/PostgreSqlClusterAliasHolder.java
@@ -16,6 +16,7 @@ import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
@@ -47,16 +48,22 @@ final class PostgreSqlClusterAliasHolder {
     }
 
     @Nonnull
-    Map<String, String> createPrimaryEnvVarsMap() {
-        final Map<String, String> envVarsMap = createCommonEnvVarsMap();
+    Map<String, String> createPrimaryEnvVarsMap(
+            final String username,
+            final String password
+    ) {
+        final Map<String, String> envVarsMap = createCommonEnvVarsMap(username, password);
         envVarsMap.put("REPMGR_NODE_NAME", primaryAlias);
         envVarsMap.put("REPMGR_NODE_NETWORK_NAME", primaryAlias);
         return envVarsMap;
     }
 
     @Nonnull
-    Map<String, String> createStandbyEnvVarsMap() {
-        final Map<String, String> envVarsMap = createCommonEnvVarsMap();
+    Map<String, String> createStandbyEnvVarsMap(
+            final String username,
+            final String password
+    ) {
+        final Map<String, String> envVarsMap = createCommonEnvVarsMap(username, password);
         envVarsMap.put("REPMGR_NODE_NAME", standbyAlias);
         envVarsMap.put("REPMGR_NODE_NETWORK_NAME", standbyAlias);
         return envVarsMap;
@@ -77,11 +84,17 @@ final class PostgreSqlClusterAliasHolder {
     }
 
     @Nonnull
-    private Map<String, String> createCommonEnvVarsMap() {
+    private Map<String, String> createCommonEnvVarsMap(
+            final String customUsername,
+            final String customPassword
+    ) {
+        final String username = Objects.requireNonNullElse(customUsername, "customuser");
+        final String password = Objects.requireNonNullElse(customPassword, "custompassword");
+
         final Map<String, String> envVarsMap = new HashMap<>();
         envVarsMap.put("POSTGRESQL_POSTGRES_PASSWORD", "adminpassword");
-        envVarsMap.put("POSTGRESQL_USERNAME", "customuser");
-        envVarsMap.put("POSTGRESQL_PASSWORD", "custompassword");
+        envVarsMap.put("POSTGRESQL_USERNAME", username);
+        envVarsMap.put("POSTGRESQL_PASSWORD", password);
         envVarsMap.put("POSTGRESQL_DATABASE", "customdatabase");
         envVarsMap.put("REPMGR_PASSWORD", "repmgrpassword");
         envVarsMap.put("REPMGR_PRIMARY_HOST", primaryAlias);

--- a/pg-index-health-testing/src/main/java/io/github/mfvanek/pg/testing/PostgreSqlClusterAliasHolder.java
+++ b/pg-index-health-testing/src/main/java/io/github/mfvanek/pg/testing/PostgreSqlClusterAliasHolder.java
@@ -49,8 +49,8 @@ final class PostgreSqlClusterAliasHolder {
 
     @Nonnull
     Map<String, String> createPrimaryEnvVarsMap(
-            final String username,
-            final String password
+            @Nonnull final String username,
+            @Nonnull final String password
     ) {
         final Map<String, String> envVarsMap = createCommonEnvVarsMap(username, password);
         envVarsMap.put("REPMGR_NODE_NAME", primaryAlias);
@@ -60,8 +60,8 @@ final class PostgreSqlClusterAliasHolder {
 
     @Nonnull
     Map<String, String> createStandbyEnvVarsMap(
-            final String username,
-            final String password
+            @Nonnull final String username,
+            @Nonnull final String password
     ) {
         final Map<String, String> envVarsMap = createCommonEnvVarsMap(username, password);
         envVarsMap.put("REPMGR_NODE_NAME", standbyAlias);
@@ -85,11 +85,11 @@ final class PostgreSqlClusterAliasHolder {
 
     @Nonnull
     private Map<String, String> createCommonEnvVarsMap(
-            final String customUsername,
-            final String customPassword
+            @Nonnull final String customUsername,
+            @Nonnull final String customPassword
     ) {
-        final String username = Objects.requireNonNullElse(customUsername, "customuser");
-        final String password = Objects.requireNonNullElse(customPassword, "custompassword");
+        final String username = Objects.requireNonNull(customUsername, "username mustn't be null");
+        final String password = Objects.requireNonNull(customPassword, "password mustn't be null");
 
         final Map<String, String> envVarsMap = new HashMap<>();
         envVarsMap.put("POSTGRESQL_POSTGRES_PASSWORD", "adminpassword");

--- a/pg-index-health-testing/src/main/java/io/github/mfvanek/pg/testing/PostgreSqlClusterWrapper.java
+++ b/pg-index-health-testing/src/main/java/io/github/mfvanek/pg/testing/PostgreSqlClusterWrapper.java
@@ -49,15 +49,13 @@ public final class PostgreSqlClusterWrapper implements AutoCloseable {
     private final JdbcDatabaseContainer<?> containerForStandBy;
     private final BasicDataSource dataSourceForPrimary;
     private final BasicDataSource dataSourceForStandBy;
-    private final String username;
-    private final String password;
 
-    private PostgreSqlClusterWrapper(final Builder builder) {
+    private PostgreSqlClusterWrapper(
+            final String username,
+            final String password
+    ) {
         this.pgVersion = PostgresVersionHolder.forCluster();
         this.network = Network.newNetwork();
-
-        this.username = builder.username;
-        this.password = builder.password;
 
         this.aliases = new PostgreSqlClusterAliasHolder();
         // Primary node
@@ -181,32 +179,37 @@ public final class PostgreSqlClusterWrapper implements AutoCloseable {
         }
     }
 
+    @Nonnull
+    public static Builder builder() {
+        return new Builder();
+    }
+
     /**
      * Provide convenient way to create cluster with single username/password.
      * If no username/password is specified, "customuser" and "custompassword" will be used as default values for username and password, respectively
      */
     public static class Builder {
 
-        private String username;
-        private String password;
+        private String username = "customuser";
+        private String password = "custompassword";
 
-        public Builder() {
-            this.username = "customuser";
-            this.password = "custompassword";
+        private Builder() {
+
         }
 
-        public Builder username(final String username) {
+        public Builder withUsername(final String username) {
             this.username = username;
             return this;
         }
 
-        public Builder password(final String password) {
+        public Builder withPassword(final String password) {
             this.password = password;
             return this;
         }
 
         public PostgreSqlClusterWrapper build() {
-            return new PostgreSqlClusterWrapper(this);
+
+            return new PostgreSqlClusterWrapper(username, password);
         }
     }
 }

--- a/pg-index-health-testing/src/main/java/io/github/mfvanek/pg/testing/PostgreSqlClusterWrapper.java
+++ b/pg-index-health-testing/src/main/java/io/github/mfvanek/pg/testing/PostgreSqlClusterWrapper.java
@@ -140,6 +140,11 @@ public final class PostgreSqlClusterWrapper implements AutoCloseable {
         return containerForPrimary.getPassword();
     }
 
+    /**
+     * Stops first container in the cluster and waits for auto failover.
+     *
+     * @return always true
+     */
     public boolean stopFirstContainer() {
         containerForPrimary.stop();
         LOGGER.info("Waiting for standby will be promoted to primary");
@@ -197,16 +202,17 @@ public final class PostgreSqlClusterWrapper implements AutoCloseable {
         private String password = "custompassword";
 
         private Builder() {
-
         }
 
-        public Builder withUsername(final String username) {
-            this.username = Objects.requireNonNull(username, "username mustn't be null");
+        @Nonnull
+        public Builder withUsername(@Nonnull final String username) {
+            this.username = Objects.requireNonNull(username, "username cannot be null");
             return this;
         }
 
-        public Builder withPassword(final String password) {
-            this.password = Objects.requireNonNull(password, "password mustn't be null");
+        @Nonnull
+        public Builder withPassword(@Nonnull final String password) {
+            this.password = Objects.requireNonNull(password, "password cannot be null");
             return this;
         }
 
@@ -215,6 +221,7 @@ public final class PostgreSqlClusterWrapper implements AutoCloseable {
          *
          * @return PostgreSqlClusterWrapper
          */
+        @Nonnull
         public PostgreSqlClusterWrapper build() {
 
             return new PostgreSqlClusterWrapper(username, password);

--- a/pg-index-health-testing/src/main/java/io/github/mfvanek/pg/testing/PostgreSqlClusterWrapper.java
+++ b/pg-index-health-testing/src/main/java/io/github/mfvanek/pg/testing/PostgreSqlClusterWrapper.java
@@ -24,6 +24,7 @@ import org.testcontainers.utility.DockerImageName;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.sql.DataSource;
@@ -51,8 +52,8 @@ public final class PostgreSqlClusterWrapper implements AutoCloseable {
     private final BasicDataSource dataSourceForStandBy;
 
     private PostgreSqlClusterWrapper(
-            final String username,
-            final String password
+            @Nonnull final String username,
+            @Nonnull final String password
     ) {
         this.pgVersion = PostgresVersionHolder.forCluster();
         this.network = Network.newNetwork();
@@ -186,7 +187,9 @@ public final class PostgreSqlClusterWrapper implements AutoCloseable {
 
     /**
      * Provide convenient way to create cluster with single username/password.
-     * If no username/password is specified, "customuser" and "custompassword" will be used as default values for username and password, respectively
+     * If no username/password is specified, "customuser" and "custompassword" will be used as default values for username and password, respectively.
+     *
+     * @author Alexey Antipin
      */
     public static class Builder {
 
@@ -198,15 +201,20 @@ public final class PostgreSqlClusterWrapper implements AutoCloseable {
         }
 
         public Builder withUsername(final String username) {
-            this.username = username;
+            this.username = Objects.requireNonNull(username, "username mustn't be null");
             return this;
         }
 
         public Builder withPassword(final String password) {
-            this.password = password;
+            this.password = Objects.requireNonNull(password, "password mustn't be null");
             return this;
         }
 
+        /**
+         * Used to create a PostgresSqlClusterWrapper with a given username/password.
+         *
+         * @return PostgreSqlClusterWrapper
+         */
         public PostgreSqlClusterWrapper build() {
 
             return new PostgreSqlClusterWrapper(username, password);

--- a/pg-index-health-testing/src/main/java/io/github/mfvanek/pg/testing/PostgresBitnamiRepmgrContainer.java
+++ b/pg-index-health-testing/src/main/java/io/github/mfvanek/pg/testing/PostgresBitnamiRepmgrContainer.java
@@ -62,11 +62,6 @@ class PostgresBitnamiRepmgrContainer extends JdbcDatabaseContainer<PostgresBitna
     }
 
     @Override
-    public String getDatabaseName() {
-        return envVars.get("POSTGRESQL_DATABASE");
-    }
-
-    @Override
     protected String getTestQueryString() {
         return "SELECT 1";
     }

--- a/pg-index-health-testing/src/test/java/io/github/mfvanek/pg/testing/PostgreSqlClusterAliasHolderTest.java
+++ b/pg-index-health-testing/src/test/java/io/github/mfvanek/pg/testing/PostgreSqlClusterAliasHolderTest.java
@@ -38,8 +38,8 @@ class PostgreSqlClusterAliasHolderTest {
         final PostgreSqlClusterAliasHolder aliases = new PostgreSqlClusterAliasHolder();
         assertThat(aliases)
                 .isNotNull()
-                .satisfies(a -> assertThat(a.createPrimaryEnvVarsMap())
+                .satisfies(a -> assertThat(a.createPrimaryEnvVarsMap("username", "password"))
                         .hasSize(14)
-                        .hasSameSizeAs(a.createStandbyEnvVarsMap()));
+                        .hasSameSizeAs(a.createStandbyEnvVarsMap("username", "password")));
     }
 }

--- a/pg-index-health-testing/src/test/java/io/github/mfvanek/pg/testing/PostgreSqlClusterAliasHolderTest.java
+++ b/pg-index-health-testing/src/test/java/io/github/mfvanek/pg/testing/PostgreSqlClusterAliasHolderTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Tag("fast")
 class PostgreSqlClusterAliasHolderTest {
@@ -41,5 +42,21 @@ class PostgreSqlClusterAliasHolderTest {
                 .satisfies(a -> assertThat(a.createPrimaryEnvVarsMap("username", "password"))
                         .hasSize(14)
                         .hasSameSizeAs(a.createStandbyEnvVarsMap("username", "password")));
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void shouldNotCreateEnvMapsWithInvalidArgs() {
+        final PostgreSqlClusterAliasHolder aliases = new PostgreSqlClusterAliasHolder();
+        assertThat(aliases)
+                .isNotNull()
+                .satisfies(a -> {
+                    assertThatThrownBy(() -> a.createPrimaryEnvVarsMap(null, null))
+                            .isInstanceOf(NullPointerException.class)
+                            .hasMessage("username cannot be null");
+                    assertThatThrownBy(() -> a.createPrimaryEnvVarsMap("username", null))
+                            .isInstanceOf(NullPointerException.class)
+                            .hasMessage("password cannot be null");
+                });
     }
 }

--- a/pg-index-health-testing/src/test/java/io/github/mfvanek/pg/testing/PostgreSqlClusterWrapperTest.java
+++ b/pg-index-health-testing/src/test/java/io/github/mfvanek/pg/testing/PostgreSqlClusterWrapperTest.java
@@ -20,7 +20,8 @@ class PostgreSqlClusterWrapperTest {
 
     @Test
     void shouldWork() {
-        try (PostgreSqlClusterWrapper cluster = new PostgreSqlClusterWrapper()) {
+        try (PostgreSqlClusterWrapper cluster = new PostgreSqlClusterWrapper.Builder().username("customuser").password("customuser").build()) {
+
             assertThat(cluster)
                     .isNotNull();
             assertThat(cluster.getDataSourceForPrimary())
@@ -40,13 +41,33 @@ class PostgreSqlClusterWrapperTest {
 
     @Test
     void stopFirstContainerShouldWork() {
-        try (PostgreSqlClusterWrapper cluster = new PostgreSqlClusterWrapper();
+        try (PostgreSqlClusterWrapper cluster = new PostgreSqlClusterWrapper.Builder().username("customuser").password("customuser").build();
              LogsCaptor logsCaptor = new LogsCaptor(PostgreSqlClusterWrapper.class)) {
             assertThat(cluster.stopFirstContainer())
                     .isTrue();
             assertThat(logsCaptor.getLogs())
                     .hasSizeGreaterThanOrEqualTo(1)
                     .anyMatch(l -> l.getMessage().contains("Waiting for standby will be promoted to primary"));
+        }
+    }
+
+    @Test
+    void builderWithDefaultFields() {
+        try (PostgreSqlClusterWrapper cluster = new PostgreSqlClusterWrapper.Builder().build()) {
+            assertThat(cluster).satisfies(it -> {
+                assertThat(it.getUsername()).isEqualTo("customuser");
+                assertThat(it.getPassword()).isEqualTo("custompassword");
+            });
+        }
+    }
+
+    @Test
+    void builderWithCustomFields() {
+        try (PostgreSqlClusterWrapper cluster = new PostgreSqlClusterWrapper.Builder().username("user").password("password").build()) {
+            assertThat(cluster).satisfies(it -> {
+                assertThat(it.getUsername()).isEqualTo("user");
+                assertThat(it.getPassword()).isEqualTo("password");
+            });
         }
     }
 }

--- a/pg-index-health-testing/src/test/java/io/github/mfvanek/pg/testing/PostgreSqlClusterWrapperTest.java
+++ b/pg-index-health-testing/src/test/java/io/github/mfvanek/pg/testing/PostgreSqlClusterWrapperTest.java
@@ -20,7 +20,7 @@ class PostgreSqlClusterWrapperTest {
 
     @Test
     void shouldWork() {
-        try (PostgreSqlClusterWrapper cluster = new PostgreSqlClusterWrapper.Builder().username("customuser").password("customuser").build()) {
+        try (PostgreSqlClusterWrapper cluster = PostgreSqlClusterWrapper.builder().build()) {
 
             assertThat(cluster)
                     .isNotNull();
@@ -41,7 +41,7 @@ class PostgreSqlClusterWrapperTest {
 
     @Test
     void stopFirstContainerShouldWork() {
-        try (PostgreSqlClusterWrapper cluster = new PostgreSqlClusterWrapper.Builder().username("customuser").password("customuser").build();
+        try (PostgreSqlClusterWrapper cluster = PostgreSqlClusterWrapper.builder().build();
              LogsCaptor logsCaptor = new LogsCaptor(PostgreSqlClusterWrapper.class)) {
             assertThat(cluster.stopFirstContainer())
                     .isTrue();
@@ -53,7 +53,7 @@ class PostgreSqlClusterWrapperTest {
 
     @Test
     void builderWithDefaultFields() {
-        try (PostgreSqlClusterWrapper cluster = new PostgreSqlClusterWrapper.Builder().build()) {
+        try (PostgreSqlClusterWrapper cluster = PostgreSqlClusterWrapper.builder().build()) {
             assertThat(cluster).satisfies(it -> {
                 assertThat(it.getUsername()).isEqualTo("customuser");
                 assertThat(it.getPassword()).isEqualTo("custompassword");
@@ -63,7 +63,7 @@ class PostgreSqlClusterWrapperTest {
 
     @Test
     void builderWithCustomFields() {
-        try (PostgreSqlClusterWrapper cluster = new PostgreSqlClusterWrapper.Builder().username("user").password("password").build()) {
+        try (PostgreSqlClusterWrapper cluster = PostgreSqlClusterWrapper.builder().withUsername("user").withPassword("password").build()) {
             assertThat(cluster).satisfies(it -> {
                 assertThat(it.getUsername()).isEqualTo("user");
                 assertThat(it.getPassword()).isEqualTo("password");

--- a/pg-index-health-testing/src/test/java/io/github/mfvanek/pg/testing/PostgreSqlClusterWrapperTest.java
+++ b/pg-index-health-testing/src/test/java/io/github/mfvanek/pg/testing/PostgreSqlClusterWrapperTest.java
@@ -15,6 +15,7 @@ import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PostgreSqlClusterWrapperTest {
 
@@ -54,20 +55,37 @@ class PostgreSqlClusterWrapperTest {
     @Test
     void builderWithDefaultFields() {
         try (PostgreSqlClusterWrapper cluster = PostgreSqlClusterWrapper.builder().build()) {
-            assertThat(cluster).satisfies(it -> {
-                assertThat(it.getUsername()).isEqualTo("customuser");
-                assertThat(it.getPassword()).isEqualTo("custompassword");
-            });
+            assertThat(cluster)
+                    .satisfies(it -> {
+                        assertThat(it.getUsername()).isEqualTo("customuser");
+                        assertThat(it.getPassword()).isEqualTo("custompassword");
+                    });
         }
     }
 
     @Test
     void builderWithCustomFields() {
-        try (PostgreSqlClusterWrapper cluster = PostgreSqlClusterWrapper.builder().withUsername("user").withPassword("password").build()) {
-            assertThat(cluster).satisfies(it -> {
-                assertThat(it.getUsername()).isEqualTo("user");
-                assertThat(it.getPassword()).isEqualTo("password");
-            });
+        try (PostgreSqlClusterWrapper cluster = PostgreSqlClusterWrapper.builder()
+                .withUsername("user")
+                .withPassword("password")
+                .build()) {
+            assertThat(cluster)
+                    .satisfies(it -> {
+                        assertThat(it.getUsername()).isEqualTo("user");
+                        assertThat(it.getPassword()).isEqualTo("password");
+                    });
         }
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void builderWithInvalidArgs() {
+        final PostgreSqlClusterWrapper.Builder builder = PostgreSqlClusterWrapper.builder();
+        assertThatThrownBy(() -> builder.withUsername(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("username cannot be null");
+        assertThatThrownBy(() -> builder.withPassword(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("password cannot be null");
     }
 }

--- a/pg-index-health-testing/src/test/java/io/github/mfvanek/pg/testing/PostgresBitnamiRepmgrContainerTest.java
+++ b/pg-index-health-testing/src/test/java/io/github/mfvanek/pg/testing/PostgresBitnamiRepmgrContainerTest.java
@@ -28,7 +28,7 @@ class PostgresBitnamiRepmgrContainerTest {
     @Test
     void containerShouldWork() {
         final PostgreSqlClusterAliasHolder aliasHolder = new PostgreSqlClusterAliasHolder();
-        try (PostgresBitnamiRepmgrContainer container = new PostgresBitnamiRepmgrContainer(prepareDockerImageName(), aliasHolder.createPrimaryEnvVarsMap())
+        try (PostgresBitnamiRepmgrContainer container = new PostgresBitnamiRepmgrContainer(prepareDockerImageName(), aliasHolder.createPrimaryEnvVarsMap("username", "password"))
                 .withCreateContainerCmdModifier(cmd -> cmd.withName(aliasHolder.getPrimaryAlias()))
                 .withSharedMemorySize(MemoryUnit.MB.convertToBytes(768))
                 .withTmpFs(Map.of("/var/lib/postgresql/data", "rw"))
@@ -55,14 +55,14 @@ class PostgresBitnamiRepmgrContainerTest {
     @Test
     void testEqualsAndHashCode() {
         final PostgreSqlClusterAliasHolder aliasHolder = new PostgreSqlClusterAliasHolder();
-        try (PostgresBitnamiRepmgrContainer first = new PostgresBitnamiRepmgrContainer(prepareDockerImageName(), aliasHolder.createPrimaryEnvVarsMap());
-             PostgresBitnamiRepmgrContainer second = new PostgresBitnamiRepmgrContainer(prepareDockerImageName(), aliasHolder.createStandbyEnvVarsMap())) {
+        try (PostgresBitnamiRepmgrContainer first = new PostgresBitnamiRepmgrContainer(prepareDockerImageName(), aliasHolder.createPrimaryEnvVarsMap("username", "password"));
+             PostgresBitnamiRepmgrContainer second = new PostgresBitnamiRepmgrContainer(prepareDockerImageName(), aliasHolder.createStandbyEnvVarsMap("username", "password"))) {
             assertThat(first)
                     .isNotNull()
                     .isNotEqualTo(null)
                     .isEqualTo(first)
                     .isNotEqualTo(BigDecimal.ONE)
-                    .doesNotHaveSameHashCodeAs(aliasHolder.createPrimaryEnvVarsMap())
+                    .doesNotHaveSameHashCodeAs(aliasHolder.createPrimaryEnvVarsMap("username", "password"))
                     .isNotEqualTo(second)
                     .doesNotHaveSameHashCodeAs(second);
         }

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/e2e/PgConnectionAwareCluster.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/e2e/PgConnectionAwareCluster.java
@@ -28,7 +28,7 @@ final class PgConnectionAwareCluster implements AutoCloseable {
 
     // on some systems promoting to primary could take up to minute and even more
     public static final Duration MAX_WAIT_INTERVAL_SECONDS = PostgreSqlClusterWrapper.WAIT_INTERVAL_SECONDS.multipliedBy(2L);
-    private final PostgreSqlClusterWrapper postgresCluster = new PostgreSqlClusterWrapper.Builder().build();
+    private final PostgreSqlClusterWrapper postgresCluster = PostgreSqlClusterWrapper.builder().build();
 
     /**
      * {@inheritDoc}

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/e2e/PgConnectionAwareCluster.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/e2e/PgConnectionAwareCluster.java
@@ -28,7 +28,7 @@ final class PgConnectionAwareCluster implements AutoCloseable {
 
     // on some systems promoting to primary could take up to minute and even more
     public static final Duration MAX_WAIT_INTERVAL_SECONDS = PostgreSqlClusterWrapper.WAIT_INTERVAL_SECONDS.multipliedBy(2L);
-    private final PostgreSqlClusterWrapper postgresCluster = new PostgreSqlClusterWrapper();
+    private final PostgreSqlClusterWrapper postgresCluster = new PostgreSqlClusterWrapper.Builder().build();
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Because of the inability to get some parameters from Datasource, I had to add the ability to set these parameters from client code.

Other solutions involve unreliable things such type cast or using additional dependencies, which I don't want to do.

https://github.com/mfvanek/pg-index-health-spring-boot-demo/issues/11