### PR TITLE
Add a check for tables where the primary key columns are not first [schemacrawler]

### DIFF
--- a/doc/available_checks.md
+++ b/doc/available_checks.md
@@ -47,6 +47,7 @@ All checks can be divided into two groups:
 | 33 | Columns with [money](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_money) type                                      | static             | yes                                                         | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_money_type.sql)                    |
 | 34 | Indexes with a [timestamp in the middle](https://habr.com/ru/companies/tensor/articles/488104/)                                    | static             | yes                                                         | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/indexes_with_timestamp_in_the_middle.sql)       |
 | 35 | Columns with a [timestamp](https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_timestamp_.28without_time_zone.29) type      | static             | yes                                                         | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_timestamp_or_timetz_type.sql)      |
+| 36 | Tables where the primary key columns are not first                                                                                 | static             | yes                                                         | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_where_primary_key_columns_not_first.sql) |
 
 ### Raw SQL queries to use with other languages
 

--- a/doc/rus/tables_where_primary_key_columns_not_first.md
+++ b/doc/rus/tables_where_primary_key_columns_not_first.md
@@ -1,0 +1,58 @@
+# Проверка наличия таблиц, где столбцы первичного ключа стоят не первыми в списке
+
+## Почему следует обращать внимание на такие первичные ключи?
+
+Размещение первичного ключа (**primary key**) первым столбцом в таблице не является технической необходимостью,
+но важно как часть стиля и соглашений:
+
+* Читаемость: сразу видно ключ при просмотре схемы; упрощает понимание структуры.
+* Согласованность: единый шаблон (**primary key** идёт первым) снижает «сюрпризы» при работе с разными схемами.
+* Запросы: в `select` запросах **primary key** всегда будет первой колонкой, что упрощает отладку и повышает наглядность.
+* Исторические практики: это устоявшаяся традиция, которая помогает поддерживать единый стиль во всех таблицах.
+
+## SQL запрос
+
+- [tables_where_primary_key_columns_not_first.sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_where_primary_key_columns_not_first.sql)
+
+## Тип проверки
+
+- **static** (может выполняться на пустой БД в компонентных\интеграционных тестах)
+
+## Поддержка секционированных таблиц
+
+Поддерживает секционированные таблицы.
+Проверка выполняется на самой секционированной таблице (родительской). Отдельные секции (потомки) игнорируются.
+
+## Скрипт для воспроизведения
+
+```sql
+create schema if not exists demo;
+
+create table if not exists demo.good_pk (
+    product_type text not null,
+    description text not null,
+    product_subtype text not null,
+    primary key (product_type, product_subtype)
+);
+
+create table if not exists demo.not_good_pk (
+    description text not null,
+    product_type text not null,
+    product_subtype text not null,
+    primary key (product_type, product_subtype)
+);
+
+create table if not exists demo."bad-pk" (
+    description text not null,
+    id bigint generated always as identity primary key
+);
+
+create table if not exists demo."bad-pk_partitioned" (
+    description text not null,
+    id uuid not null primary key,
+    created_at timestamptz not null default now()
+) partition by hash (id);
+
+create table if not exists demo."bad_pk_partitioned_hash_p0"
+    partition of demo."bad-pk_partitioned" for values with (modulus 4, remainder 0);
+```

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/Diagnostic.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/Diagnostic.java
@@ -167,7 +167,7 @@ public enum Diagnostic implements CheckTypeAware {
      */
     public enum ExecutionTopology {
         /**
-         * Only on primary host.
+         * Only on the primary host.
          */
         ON_PRIMARY,
         /**

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/Diagnostic.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/Diagnostic.java
@@ -57,7 +57,8 @@ public enum Diagnostic implements CheckTypeAware {
     PRIMARY_KEYS_THAT_MOST_LIKELY_NATURAL_KEYS("primary_keys_that_most_likely_natural_keys.sql"),
     COLUMNS_WITH_MONEY_TYPE("columns_with_money_type.sql"),
     INDEXES_WITH_TIMESTAMP_IN_THE_MIDDLE("indexes_with_timestamp_in_the_middle.sql"),
-    COLUMNS_WITH_TIMESTAMP_OR_TIMETZ_TYPE("columns_with_timestamp_or_timetz_type.sql");
+    COLUMNS_WITH_TIMESTAMP_OR_TIMETZ_TYPE("columns_with_timestamp_or_timetz_type.sql"),
+    TABLES_WHERE_PRIMARY_KEY_COLUMNS_NOT_FIRST("tables_where_primary_key_columns_not_first.sql");
 
     private final ExecutionTopology executionTopology;
     private final String sqlQueryFileName;

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/QueryExecutor.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/QueryExecutor.java
@@ -31,10 +31,10 @@ public interface QueryExecutor {
      * Executes the specified SQL query using the provided {@link PgConnection} and {@link PgContext},
      * and extracts the results using the given {@link ResultSetExtractor}.
      *
-     * @param pgConnection the connection to the PostgreSQL database, must not be null
-     * @param pgContext    the context for the PostgreSQL database, must not be null
-     * @param sqlQuery     the SQL query to be executed, must not be null
-     * @param rse          the extractor used to extract results from the {@link ResultSet}, must not be null
+     * @param pgConnection the connection to the PostgreSQL database; must not be null
+     * @param pgContext    the context for the PostgreSQL database; must not be null
+     * @param sqlQuery     the SQL query to be executed; must not be null
+     * @param rse          the extractor used to extract results from the {@link ResultSet}; must not be null
      * @param <T>          the type of {@link DbObject} that the query returns
      * @return a list of results extracted by the {@link ResultSetExtractor}, never null
      */

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/RawTypeAware.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/RawTypeAware.java
@@ -13,7 +13,7 @@ package io.github.mfvanek.pg.core.checks.common;
 import io.github.mfvanek.pg.model.dbobject.DbObject;
 
 /**
- * Allows getting information about original generic type.
+ * Allows getting information about the original generic type.
  *
  * @param <T> represents an object in a database associated with a table
  * @author Ivan Vakhrushev

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/AbstractCheckOnHost.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/AbstractCheckOnHost.java
@@ -43,7 +43,7 @@ abstract class AbstractCheckOnHost<T extends DbObject> implements DatabaseCheckO
     protected static final String BLOAT_PERCENTAGE = "bloat_percentage";
 
     /**
-     * An original java type representing database object.
+     * An original java type representing a database object.
      */
     private final Class<T> type;
     /**
@@ -107,7 +107,7 @@ abstract class AbstractCheckOnHost<T extends DbObject> implements DatabaseCheckO
     protected abstract List<T> doCheck(PgContext pgContext);
 
     /**
-     * Executes query associated with diagnostic and extracts result.
+     * Executes a query associated with a diagnostic and extracts the result.
      *
      * @param pgContext check's context with the specified schema; must not be null
      * @param rse       the extractor used to extract results from the {@link ResultSet}; must not be null

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/TablesWherePrimaryKeyColumnsNotFirstCheckOnHost.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/TablesWherePrimaryKeyColumnsNotFirstCheckOnHost.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019-2025. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.core.checks.host;
+
+import io.github.mfvanek.pg.connection.PgConnection;
+import io.github.mfvanek.pg.core.checks.common.Diagnostic;
+import io.github.mfvanek.pg.core.checks.extractors.TableExtractor;
+import io.github.mfvanek.pg.model.context.PgContext;
+import io.github.mfvanek.pg.model.table.Table;
+
+import java.util.List;
+
+/**
+ * Check for tables where the primary key column is not the first column in the table on a specific host.
+ * <p>
+ * Putting the primary key as the first column improves readability, consistency, and expectations, especially in teams or large schemas.
+ *
+ * @author Ivan Vakhrushev
+ * @since 0.20.3
+ */
+public class TablesWherePrimaryKeyColumnsNotFirstCheckOnHost extends AbstractCheckOnHost<Table> {
+
+    public TablesWherePrimaryKeyColumnsNotFirstCheckOnHost(final PgConnection pgConnection) {
+        super(Table.class, pgConnection, Diagnostic.TABLES_WHERE_PRIMARY_KEY_COLUMNS_NOT_FIRST);
+    }
+
+    /**
+     * Returns tables where the primary key columns are not first in the specified schema.
+     *
+     * @param pgContext check's context with the specified schema; must not be null
+     * @return list of tables where the primary key columns are not first
+     */
+    @Override
+    protected List<Table> doCheck(final PgContext pgContext) {
+        return executeQuery(pgContext, TableExtractor.of());
+    }
+}

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/utils/QueryExecutors.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/utils/QueryExecutors.java
@@ -42,9 +42,9 @@ public final class QueryExecutors {
     /**
      * Executes a given SQL query and extracts results using the provided {@link ResultSetExtractor}.
      *
-     * @param pgConnection the PostgreSQL connection, cannot be null
-     * @param sqlQuery     the SQL query to execute, cannot be null
-     * @param rse          the result set extractor to process the {@link ResultSet}, cannot be null
+     * @param pgConnection the PostgreSQL connection; cannot be null
+     * @param sqlQuery     the SQL query to execute; cannot be null
+     * @param rse          the result set extractor to process the {@link ResultSet}; cannot be null
      * @param <T>          the type of the result
      * @return a list of results extracted by the {@link ResultSetExtractor}
      * @throws NullPointerException if any of the parameters are null
@@ -74,10 +74,10 @@ public final class QueryExecutors {
     /**
      * Executes a given SQL query within the context of the provided schema name.
      *
-     * @param pgConnection the PostgreSQL connection, cannot be null
-     * @param pgContext    the context containing the schema name, cannot be null
-     * @param sqlQuery     the SQL query to execute, cannot be null
-     * @param rse          the result set extractor to process the {@link ResultSet}, cannot be null
+     * @param pgConnection the PostgreSQL connection; cannot be null
+     * @param pgContext    the context containing the schema name; cannot be null
+     * @param sqlQuery     the SQL query to execute; cannot be null
+     * @param rse          the result set extractor to process the {@link ResultSet}; cannot be null
      * @param <T>          the type of the result
      * @return a list of results extracted by the {@link ResultSetExtractor}
      * @throws NullPointerException if any of the parameters are null
@@ -99,10 +99,10 @@ public final class QueryExecutors {
     /**
      * Executes a given SQL query within the context of the provided schema name and bloat threshold.
      *
-     * @param pgConnection the PostgreSQL connection, cannot be null
-     * @param pgContext    the context containing the schema name and bloat threshold, cannot be null
-     * @param sqlQuery     the SQL query to execute, cannot be null
-     * @param rse          the result set extractor to process the {@link ResultSet}, cannot be null
+     * @param pgConnection the PostgreSQL connection; cannot be null
+     * @param pgContext    the context containing the schema name and bloat threshold; cannot be null
+     * @param sqlQuery     the SQL query to execute; cannot be null
+     * @param rse          the result set extractor to process the {@link ResultSet}; cannot be null
      * @param <T>          the type of the result
      * @return a list of results extracted by the {@link ResultSetExtractor}
      * @throws NullPointerException if any of the parameters are null
@@ -125,10 +125,10 @@ public final class QueryExecutors {
     /**
      * Executes a given SQL query within the context of the provided schema name and remaining percentage threshold.
      *
-     * @param pgConnection the PostgreSQL connection, cannot be null
-     * @param pgContext    the context containing the schema name and remaining percentage threshold, cannot be null
-     * @param sqlQuery     the SQL query to execute, cannot be null
-     * @param rse          the result set extractor to process the {@link ResultSet}, cannot be null
+     * @param pgConnection the PostgreSQL connection; cannot be null
+     * @param pgContext    the context containing the schema name and remaining percentage threshold; cannot be null
+     * @param sqlQuery     the SQL query to execute; cannot be null
+     * @param rse          the result set extractor to process the {@link ResultSet}; cannot be null
      * @param <T>          the type of the result
      * @return a list of results extracted by the {@link ResultSetExtractor}
      * @throws NullPointerException if any of the parameters are null

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/BtreeIndexesOnArrayColumnsCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/BtreeIndexesOnArrayColumnsCheckOnHostTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.IndexWithColumns;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,7 +26,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class BtreeIndexesOnArrayColumnsCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<IndexWithColumns> check = new BtreeIndexesOnArrayColumnsCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull IndexWithColumns> check = new BtreeIndexesOnArrayColumnsCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsNotFollowingNamingConventionCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsNotFollowingNamingConventionCheckOnHostTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.core.fixtures.support.DatabasePopulator;
 import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -27,7 +28,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class ColumnsNotFollowingNamingConventionCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<Column> check = new ColumnsNotFollowingNamingConventionCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull Column> check = new ColumnsNotFollowingNamingConventionCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsWithFixedLengthVarcharCheckTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsWithFixedLengthVarcharCheckTest.java
@@ -16,6 +16,7 @@ import io.github.mfvanek.pg.core.fixtures.support.DatabaseAwareTestBase;
 import io.github.mfvanek.pg.core.fixtures.support.DatabasePopulator;
 import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -24,7 +25,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class ColumnsWithFixedLengthVarcharCheckTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<Column> check = new ColumnsWithFixedLengthVarcharCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull Column> check = new ColumnsWithFixedLengthVarcharCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsWithJsonTypeCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsWithJsonTypeCheckOnHostTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipByColumnNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -26,7 +27,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class ColumnsWithJsonTypeCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<Column> check = new ColumnsWithJsonTypeCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull Column> check = new ColumnsWithJsonTypeCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsWithMoneyTypeCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsWithMoneyTypeCheckOnHostTest.java
@@ -16,6 +16,7 @@ import io.github.mfvanek.pg.core.fixtures.support.DatabaseAwareTestBase;
 import io.github.mfvanek.pg.core.fixtures.support.DatabasePopulator;
 import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -24,7 +25,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class ColumnsWithMoneyTypeCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<Column> check = new ColumnsWithMoneyTypeCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull Column> check = new ColumnsWithMoneyTypeCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsWithSerialTypesCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsWithSerialTypesCheckOnHostTest.java
@@ -19,6 +19,7 @@ import io.github.mfvanek.pg.model.column.ColumnWithSerialType;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipBySequenceNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -29,7 +30,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class ColumnsWithSerialTypesCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<ColumnWithSerialType> check = new ColumnsWithSerialTypesCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull ColumnWithSerialType> check = new ColumnsWithSerialTypesCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsWithTimestampOrTimetzTypeCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsWithTimestampOrTimetzTypeCheckOnHostTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.column.ColumnWithType;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -26,7 +27,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class ColumnsWithTimestampOrTimetzTypeCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<ColumnWithType> check = new ColumnsWithTimestampOrTimetzTypeCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull ColumnWithType> check = new ColumnsWithTimestampOrTimetzTypeCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsWithoutDescriptionCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsWithoutDescriptionCheckOnHostTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.core.fixtures.support.DatabasePopulator;
 import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -27,7 +28,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class ColumnsWithoutDescriptionCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<Column> check = new ColumnsWithoutDescriptionCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull Column> check = new ColumnsWithoutDescriptionCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsWithoutDescriptionCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ColumnsWithoutDescriptionCheckOnHostTest.java
@@ -109,9 +109,10 @@ class ColumnsWithoutDescriptionCheckOnHostTest extends DatabaseAwareTestBase {
         executeTestOnDatabase(schemaName, DatabasePopulator::withPartitionedTableWithoutComments, ctx ->
             assertThat(check)
                 .executing(ctx, SkipTablesByNamePredicate.of(ctx, List.of("accounts", "clients")))
-                .hasSize(4)
+                .hasSize(5)
                 .containsExactly(
                     Column.ofNotNull(ctx, expectedTableName, "creation_date"),
+                    Column.ofNullable(ctx, expectedTableName, "description"),
                     Column.ofNotNull(ctx, expectedTableName, "entity_id"),
                     Column.ofNotNull(ctx, expectedTableName, "ref_type"),
                     Column.ofNotNull(ctx, expectedTableName, "ref_value")));

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/DuplicatedForeignKeysCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/DuplicatedForeignKeysCheckOnHostTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.model.constraint.DuplicatedForeignKeys;
 import io.github.mfvanek.pg.model.constraint.ForeignKey;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,7 +26,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class DuplicatedForeignKeysCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<DuplicatedForeignKeys> check = new DuplicatedForeignKeysCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull DuplicatedForeignKeys> check = new DuplicatedForeignKeysCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/DuplicatedIndexesCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/DuplicatedIndexesCheckOnHostTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.index.DuplicatedIndexes;
 import io.github.mfvanek.pg.model.index.Index;
 import io.github.mfvanek.pg.model.predicates.SkipIndexesByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -26,7 +27,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class DuplicatedIndexesCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<DuplicatedIndexes> check = new DuplicatedIndexesCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull DuplicatedIndexes> check = new DuplicatedIndexesCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ForeignKeysNotCoveredWithIndexCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ForeignKeysNotCoveredWithIndexCheckOnHostTest.java
@@ -19,6 +19,7 @@ import io.github.mfvanek.pg.model.constraint.ForeignKey;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipByConstraintNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -29,7 +30,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class ForeignKeysNotCoveredWithIndexCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<ForeignKey> check = new ForeignKeysNotCoveredWithIndexCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull ForeignKey> check = new ForeignKeysNotCoveredWithIndexCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ForeignKeysWithUnmatchedColumnTypeCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ForeignKeysWithUnmatchedColumnTypeCheckOnHostTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.core.fixtures.support.DatabasePopulator;
 import io.github.mfvanek.pg.model.constraint.ForeignKey;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,7 +26,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class ForeignKeysWithUnmatchedColumnTypeCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<ForeignKey> check = new ForeignKeysWithUnmatchedColumnTypeCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull ForeignKey> check = new ForeignKeysWithUnmatchedColumnTypeCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/FunctionsWithoutDescriptionCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/FunctionsWithoutDescriptionCheckOnHostTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.core.fixtures.support.DatabasePopulator;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.function.StoredFunction;
 import io.github.mfvanek.pg.model.predicates.SkipDbObjectsByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,7 +27,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class FunctionsWithoutDescriptionCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<StoredFunction> check = new FunctionsWithoutDescriptionCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull StoredFunction> check = new FunctionsWithoutDescriptionCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IndexesWithBloatCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IndexesWithBloatCheckOnHostTest.java
@@ -20,6 +20,7 @@ import io.github.mfvanek.pg.model.predicates.SkipIndexesByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipSmallIndexesPredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import org.assertj.core.api.Assertions;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -30,7 +31,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class IndexesWithBloatCheckOnHostTest extends StatisticsAwareTestBase {
 
-    private final DatabaseCheckOnHost<IndexWithBloat> check = new IndexesWithBloatCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull IndexWithBloat> check = new IndexesWithBloatCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IndexesWithBooleanCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IndexesWithBooleanCheckOnHostTest.java
@@ -19,6 +19,7 @@ import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.IndexWithColumns;
 import io.github.mfvanek.pg.model.predicates.SkipIndexesByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -27,7 +28,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class IndexesWithBooleanCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<IndexWithColumns> check = new IndexesWithBooleanCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull IndexWithColumns> check = new IndexesWithBooleanCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IndexesWithNullValuesCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IndexesWithNullValuesCheckOnHostTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.IndexWithColumns;
 import io.github.mfvanek.pg.model.predicates.SkipIndexesByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -26,7 +27,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class IndexesWithNullValuesCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<IndexWithColumns> check = new IndexesWithNullValuesCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull IndexWithColumns> check = new IndexesWithNullValuesCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IndexesWithTimestampInTheMiddleCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IndexesWithTimestampInTheMiddleCheckOnHostTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.IndexWithColumns;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class IndexesWithTimestampInTheMiddleCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<IndexWithColumns> check = new IndexesWithTimestampInTheMiddleCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull IndexWithColumns> check = new IndexesWithTimestampInTheMiddleCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IndexesWithUnnecessaryWhereClauseCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IndexesWithUnnecessaryWhereClauseCheckOnHostTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.IndexWithColumns;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class IndexesWithUnnecessaryWhereClauseCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<IndexWithColumns> check = new IndexesWithUnnecessaryWhereClauseCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull IndexWithColumns> check = new IndexesWithUnnecessaryWhereClauseCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IntersectedForeignKeysCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IntersectedForeignKeysCheckOnHostTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.constraint.DuplicatedForeignKeys;
 import io.github.mfvanek.pg.model.constraint.ForeignKey;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class IntersectedForeignKeysCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<DuplicatedForeignKeys> check = new IntersectedForeignKeysCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull DuplicatedForeignKeys> check = new IntersectedForeignKeysCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IntersectedIndexesCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IntersectedIndexesCheckOnHostTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.index.DuplicatedIndexes;
 import io.github.mfvanek.pg.model.index.Index;
 import io.github.mfvanek.pg.model.predicates.SkipIndexesByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class IntersectedIndexesCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<DuplicatedIndexes> check = new IntersectedIndexesCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull DuplicatedIndexes> check = new IntersectedIndexesCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/InvalidIndexesCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/InvalidIndexesCheckOnHostTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.Index;
 import io.github.mfvanek.pg.model.predicates.SkipIndexesByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,7 +26,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class InvalidIndexesCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<Index> check = new InvalidIndexesCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull Index> check = new InvalidIndexesCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/NotValidConstraintsCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/NotValidConstraintsCheckOnHostTest.java
@@ -19,6 +19,7 @@ import io.github.mfvanek.pg.model.constraint.ConstraintType;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import org.assertj.core.api.Assertions;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -29,7 +30,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class NotValidConstraintsCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<Constraint> check = new NotValidConstraintsCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull Constraint> check = new NotValidConstraintsCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ObjectsNotFollowingNamingConventionCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ObjectsNotFollowingNamingConventionCheckOnHostTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.dbobject.AnyObject;
 import io.github.mfvanek.pg.model.dbobject.PgObjectType;
 import io.github.mfvanek.pg.model.predicates.SkipDbObjectsByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class ObjectsNotFollowingNamingConventionCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<AnyObject> check = new ObjectsNotFollowingNamingConventionCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull AnyObject> check = new ObjectsNotFollowingNamingConventionCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/PossibleObjectNameOverflowCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/PossibleObjectNameOverflowCheckOnHostTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.dbobject.AnyObject;
 import io.github.mfvanek.pg.model.dbobject.PgObjectType;
 import io.github.mfvanek.pg.model.predicates.SkipDbObjectsByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class PossibleObjectNameOverflowCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<AnyObject> check = new PossibleObjectNameOverflowCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull AnyObject> check = new PossibleObjectNameOverflowCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/PrimaryKeysThatMostLikelyNaturalKeysCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/PrimaryKeysThatMostLikelyNaturalKeysCheckOnHostTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.IndexWithColumns;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class PrimaryKeysThatMostLikelyNaturalKeysCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<IndexWithColumns> check = new PrimaryKeysThatMostLikelyNaturalKeysCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull IndexWithColumns> check = new PrimaryKeysThatMostLikelyNaturalKeysCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/PrimaryKeysWithSerialTypesCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/PrimaryKeysWithSerialTypesCheckOnHostTest.java
@@ -20,6 +20,7 @@ import io.github.mfvanek.pg.model.column.SerialType;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipBySequenceNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -30,7 +31,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class PrimaryKeysWithSerialTypesCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<ColumnWithSerialType> check = new PrimaryKeysWithSerialTypesCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull ColumnWithSerialType> check = new PrimaryKeysWithSerialTypesCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/PrimaryKeysWithVarcharCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/PrimaryKeysWithVarcharCheckOnHostTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.IndexWithColumns;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class PrimaryKeysWithVarcharCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<IndexWithColumns> check = new PrimaryKeysWithVarcharCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull IndexWithColumns> check = new PrimaryKeysWithVarcharCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/SequenceOverflowCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/SequenceOverflowCheckOnHostTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.core.fixtures.support.DatabasePopulator;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipBySequenceNamePredicate;
 import io.github.mfvanek.pg.model.sequence.SequenceState;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -27,7 +28,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class SequenceOverflowCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<SequenceState> check = new SequenceOverflowCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull SequenceState> check = new SequenceOverflowCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWherePrimaryKeyColumnsNotFirstCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWherePrimaryKeyColumnsNotFirstCheckOnHostTest.java
@@ -15,7 +15,6 @@ import io.github.mfvanek.pg.core.checks.common.Diagnostic;
 import io.github.mfvanek.pg.core.fixtures.support.DatabaseAwareTestBase;
 import io.github.mfvanek.pg.core.fixtures.support.DatabasePopulator;
 import io.github.mfvanek.pg.model.context.PgContext;
-import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import io.github.mfvanek.pg.model.table.Table;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
@@ -40,12 +39,14 @@ class TablesWherePrimaryKeyColumnsNotFirstCheckOnHostTest extends DatabaseAwareT
     @ParameterizedTest
     @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
     void onDatabaseWithThem(final String schemaName) {
-        executeTestOnDatabase(schemaName, dbp -> dbp.withReferences().withTableWithoutPrimaryKey(), ctx -> {
+        executeTestOnDatabase(schemaName, DatabasePopulator::withNaturalKeys, ctx ->
             assertThat(check)
                 .executing(ctx)
-                .hasSize(1)
-                .containsExactly(Table.of(ctx, "bad_clients")); // TODO
-        });
+                .hasSize(2)
+                .containsExactly(
+                    Table.of(ctx, "t2_composite"),
+                    Table.of(ctx, "\"times-of-creation\"")
+                ));
     }
 
     @ParameterizedTest

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWithBloatCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWithBloatCheckOnHostTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.predicates.SkipBloatUnderThresholdPredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import io.github.mfvanek.pg.model.table.TableWithBloat;
 import org.assertj.core.api.Assertions;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class TablesWithBloatCheckOnHostTest extends StatisticsAwareTestBase {
 
-    private final DatabaseCheckOnHost<TableWithBloat> check = new TablesWithBloatCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull TableWithBloat> check = new TablesWithBloatCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWithMissingIndexesCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWithMissingIndexesCheckOnHostTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipSmallTablesPredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import io.github.mfvanek.pg.model.table.TableWithMissingIndex;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,7 +26,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class TablesWithMissingIndexesCheckOnHostTest extends StatisticsAwareTestBase {
 
-    private final DatabaseCheckOnHost<TableWithMissingIndex> check = new TablesWithMissingIndexesCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull TableWithMissingIndex> check = new TablesWithMissingIndexesCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWithZeroOrOneColumnCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWithZeroOrOneColumnCheckOnHostTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.core.fixtures.support.DatabasePopulator;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import io.github.mfvanek.pg.model.table.TableWithColumns;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -27,7 +28,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class TablesWithZeroOrOneColumnCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<TableWithColumns> check = new TablesWithZeroOrOneColumnCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull TableWithColumns> check = new TablesWithZeroOrOneColumnCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWithoutDescriptionCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWithoutDescriptionCheckOnHostTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipSmallTablesPredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import io.github.mfvanek.pg.model.table.Table;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class TablesWithoutDescriptionCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<Table> check = new TablesWithoutDescriptionCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull Table> check = new TablesWithoutDescriptionCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWithoutPrimaryKeyCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWithoutPrimaryKeyCheckOnHostTest.java
@@ -16,6 +16,7 @@ import io.github.mfvanek.pg.core.fixtures.support.DatabaseAwareTestBase;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import io.github.mfvanek.pg.model.table.Table;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -24,7 +25,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class TablesWithoutPrimaryKeyCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<Table> check = new TablesWithoutPrimaryKeyCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull Table> check = new TablesWithoutPrimaryKeyCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/UnusedIndexesCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/UnusedIndexesCheckOnHostTest.java
@@ -19,6 +19,7 @@ import io.github.mfvanek.pg.model.index.UnusedIndex;
 import io.github.mfvanek.pg.model.predicates.SkipDbObjectsByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipIndexesByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -29,7 +30,7 @@ import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assert
 
 class UnusedIndexesCheckOnHostTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnHost<UnusedIndex> check = new UnusedIndexesCheckOnHost(getPgConnection());
+    private final DatabaseCheckOnHost<@NonNull UnusedIndex> check = new UnusedIndexesCheckOnHost(getPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/CreatePartitionedTableWithoutCommentsStatement.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/CreatePartitionedTableWithoutCommentsStatement.java
@@ -19,6 +19,7 @@ public class CreatePartitionedTableWithoutCommentsStatement extends AbstractDbSt
         return List.of(
             """
                 create table if not exists {schemaName}.custom_entity_reference_with_very_very_very_long_name(
+                    description text,
                     ref_type varchar(32) not null,
                     ref_value varchar(64) not null,
                     creation_date timestamp with time zone not null,

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/CreateTableWithNaturalKeyStatement.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/CreateTableWithNaturalKeyStatement.java
@@ -22,9 +22,11 @@ public class CreateTableWithNaturalKeyStatement extends AbstractDbStatement {
                     id int not null primary key);""",
             """
                 create table if not exists {schemaName}."times-of-creation" (
+                    description text not null,
                     "time-of-creation" timestamptz not null primary key);""",
             """
                 create table if not exists {schemaName}.t2_composite (
+                    issue_date timestamptz not null,
                     passport_series text not null,
                     passport_number text not null,
                     primary key (passport_series, passport_number)
@@ -32,6 +34,7 @@ public class CreateTableWithNaturalKeyStatement extends AbstractDbStatement {
             """
                 create table if not exists {schemaName}.t3_composite (
                     app_id uuid not null,
+                    column_in_the_middle text,
                     app_number text not null,
                     primary key (app_id, app_number)
                 );"""

--- a/pg-index-health-logger/src/main/java/io/github/mfvanek/pg/health/logger/AbstractHealthLogger.java
+++ b/pg-index-health-logger/src/main/java/io/github/mfvanek/pg/health/logger/AbstractHealthLogger.java
@@ -62,7 +62,7 @@ public abstract class AbstractHealthLogger implements HealthLogger {
         final DatabaseChecksOnCluster databaseChecksOnCluster = databaseChecksFactory.apply(haPgConnection);
         final Predicate<DbObject> jointFilters = prepareFilters(exclusions, pgContext);
         final List<String> logResult = new ArrayList<>();
-        for (final DatabaseCheckOnCluster<? extends DbObject> check : databaseChecksOnCluster.getAll()) {
+        for (final DatabaseCheckOnCluster<? extends DbObject> check : databaseChecksOnCluster.get()) {
             final LoggingKey key = SimpleLoggingKeyAdapter.of(check.getDiagnostic());
             final List<? extends DbObject> checkResult = check.check(pgContext, jointFilters);
             if (checkResult.isEmpty()) {
@@ -84,6 +84,13 @@ public abstract class AbstractHealthLogger implements HealthLogger {
             .and(SkipSmallIndexesPredicate.of(exclusions.getIndexSizeThresholdInBytes()));
     }
 
+    /**
+     * Writes the provided key and value to a log.
+     *
+     * @param key the {@code LoggingKey} object representing the key to be logged; must not be {@code null}.
+     * @param value the integer value associated with the key that will be logged.
+     * @return a message indicating the result of the logging operation; never {@code null}.
+     */
     protected abstract String writeToLog(LoggingKey key, int value);
 
     private String writeZeroToLog(final LoggingKey key) {

--- a/pg-index-health-logger/src/main/java/io/github/mfvanek/pg/health/logger/DatabaseChecksOnCluster.java
+++ b/pg-index-health-logger/src/main/java/io/github/mfvanek/pg/health/logger/DatabaseChecksOnCluster.java
@@ -50,6 +50,7 @@ import io.github.mfvanek.pg.health.checks.common.DatabaseCheckOnCluster;
 import io.github.mfvanek.pg.model.dbobject.DbObject;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * A class that aggregates various database checks on a PostgreSQL cluster.
@@ -65,7 +66,7 @@ import java.util.List;
  * @see DatabaseCheckOnCluster
  */
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
-public final class DatabaseChecksOnCluster {
+public final class DatabaseChecksOnCluster implements Supplier<List<DatabaseCheckOnCluster<? extends DbObject>>> {
 
     private final List<DatabaseCheckOnCluster<? extends DbObject>> checks;
 
@@ -121,7 +122,16 @@ public final class DatabaseChecksOnCluster {
      *
      * @return an immutable list of {@link DatabaseCheckOnCluster} instances
      */
+    @Deprecated(since = "0.20.3", forRemoval = true)
     public List<DatabaseCheckOnCluster<? extends DbObject>> getAll() {
+        return get();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<DatabaseCheckOnCluster<? extends DbObject>> get() {
         return checks;
     }
 }

--- a/pg-index-health-logger/src/main/java/io/github/mfvanek/pg/health/logger/DatabaseChecksOnCluster.java
+++ b/pg-index-health-logger/src/main/java/io/github/mfvanek/pg/health/logger/DatabaseChecksOnCluster.java
@@ -123,6 +123,7 @@ public final class DatabaseChecksOnCluster implements Supplier<List<DatabaseChec
      * Returns the list of all configured database checks.
      *
      * @return an immutable list of {@link DatabaseCheckOnCluster} instances
+     * @deprecated since 0.20.3, use {@link #get()} instead
      */
     @Deprecated(since = "0.20.3", forRemoval = true)
     public List<DatabaseCheckOnCluster<? extends DbObject>> getAll() {

--- a/pg-index-health-logger/src/main/java/io/github/mfvanek/pg/health/logger/DatabaseChecksOnCluster.java
+++ b/pg-index-health-logger/src/main/java/io/github/mfvanek/pg/health/logger/DatabaseChecksOnCluster.java
@@ -40,6 +40,7 @@ import io.github.mfvanek.pg.health.checks.cluster.PrimaryKeysWithSerialTypesChec
 import io.github.mfvanek.pg.health.checks.cluster.PrimaryKeysWithVarcharCheckOnCluster;
 import io.github.mfvanek.pg.health.checks.cluster.SequenceOverflowCheckOnCluster;
 import io.github.mfvanek.pg.health.checks.cluster.TablesNotLinkedToOthersCheckOnCluster;
+import io.github.mfvanek.pg.health.checks.cluster.TablesWherePrimaryKeyColumnsNotFirstCheckOnCluster;
 import io.github.mfvanek.pg.health.checks.cluster.TablesWithBloatCheckOnCluster;
 import io.github.mfvanek.pg.health.checks.cluster.TablesWithMissingIndexesCheckOnCluster;
 import io.github.mfvanek.pg.health.checks.cluster.TablesWithZeroOrOneColumnCheckOnCluster;
@@ -113,7 +114,8 @@ public final class DatabaseChecksOnCluster implements Supplier<List<DatabaseChec
             new PrimaryKeysThatMostLikelyNaturalKeysCheckOnCluster(haPgConnection),
             new ColumnsWithMoneyTypeCheckOnCluster(haPgConnection),
             new IndexesWithTimestampInTheMiddleCheckOnCluster(haPgConnection),
-            new ColumnsWithTimestampOrTimetzTypeCheckOnCluster(haPgConnection)
+            new ColumnsWithTimestampOrTimetzTypeCheckOnCluster(haPgConnection),
+            new TablesWherePrimaryKeyColumnsNotFirstCheckOnCluster(haPgConnection)
         );
     }
 

--- a/pg-index-health-logger/src/main/java/io/github/mfvanek/pg/health/logger/LoggingKey.java
+++ b/pg-index-health-logger/src/main/java/io/github/mfvanek/pg/health/logger/LoggingKey.java
@@ -26,9 +26,9 @@ public interface LoggingKey {
     String getKeyName();
 
     /**
-     * Gets the name of the sub-key associated with this key.
+     * Gets the name of the subkey associated with this key.
      *
-     * @return the sub-key name, never {@code null}.
+     * @return the subkey name, never {@code null}.
      */
     String getSubKeyName();
 

--- a/pg-index-health-logger/src/main/java/io/github/mfvanek/pg/health/logger/SimpleLoggingKeyAdapter.java
+++ b/pg-index-health-logger/src/main/java/io/github/mfvanek/pg/health/logger/SimpleLoggingKeyAdapter.java
@@ -19,7 +19,7 @@ import java.util.Locale;
  * based on a {@link Diagnostic} instance.
  *
  * <p>This class implements the {@link LoggingKey} interface by deriving the key name,
- * sub-key name, and description from the given {@link Diagnostic} object.</p>
+ * subkey name, and description from the given {@link Diagnostic} object.</p>
  */
 public final class SimpleLoggingKeyAdapter implements LoggingKey {
 

--- a/pg-index-health-logger/src/main/java/io/github/mfvanek/pg/health/logger/StandardHealthLogger.java
+++ b/pg-index-health-logger/src/main/java/io/github/mfvanek/pg/health/logger/StandardHealthLogger.java
@@ -29,6 +29,9 @@ public class StandardHealthLogger extends AbstractHealthLogger {
         super(credentials, connectionFactory, databaseChecksFactory);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected String writeToLog(final LoggingKey key, final int value) {
         return key.getSubKeyName() + ":" + value;

--- a/pg-index-health-logger/src/test/java/io/github/mfvanek/pg/health/logger/StandardHealthLoggerTest.java
+++ b/pg-index-health-logger/src/test/java/io/github/mfvanek/pg/health/logger/StandardHealthLoggerTest.java
@@ -101,7 +101,7 @@ class StandardHealthLoggerTest extends StatisticsAwareTestBase {
                         "unused_indexes:19",
                         "tables_with_missing_indexes:0",
                         "tables_without_description:21",
-                        "columns_without_description:51",
+                        "columns_without_description:54",
                         "columns_with_json_type:1",
                         "columns_with_serial_types:3",
                         "functions_without_description:3",
@@ -115,7 +115,7 @@ class StandardHealthLoggerTest extends StatisticsAwareTestBase {
                         "possible_object_name_overflow:2",
                         "tables_not_linked_to_others:10",
                         "foreign_keys_with_unmatched_column_type:2",
-                        "tables_with_zero_or_one_column:8",
+                        "tables_with_zero_or_one_column:7",
                         "objects_not_following_naming_convention:21",
                         "columns_not_following_naming_convention:7",
                         "primary_keys_with_varchar:3",
@@ -124,7 +124,8 @@ class StandardHealthLoggerTest extends StatisticsAwareTestBase {
                         "primary_keys_that_most_likely_natural_keys:6",
                         "columns_with_money_type:1",
                         "indexes_with_timestamp_in_the_middle:3",
-                        "columns_with_timestamp_or_timetz_type:4"
+                        "columns_with_timestamp_or_timetz_type:4",
+                        "tables_where_primary_key_columns_not_first:2"
                     );
             }
         );

--- a/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/AbstractCheckOnCluster.java
+++ b/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/AbstractCheckOnCluster.java
@@ -30,7 +30,7 @@ import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 /**
- * An abstract class for all database checks performed on entire cluster.
+ * An abstract class for all database checks performed on the entire cluster.
  *
  * @param <T> represents an object in a database associated with a table
  * @author Ivan Vakhrushev

--- a/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/TablesWherePrimaryKeyColumnsNotFirstCheckOnCluster.java
+++ b/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/TablesWherePrimaryKeyColumnsNotFirstCheckOnCluster.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019-2025. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.health.checks.cluster;
+
+import io.github.mfvanek.pg.connection.HighAvailabilityPgConnection;
+import io.github.mfvanek.pg.core.checks.host.TablesWherePrimaryKeyColumnsNotFirstCheckOnHost;
+import io.github.mfvanek.pg.model.table.Table;
+
+/**
+ * Check for tables where the primary key column is not the first column in the table on all hosts in the cluster.
+ * <p>
+ * Putting the primary key as the first column improves readability, consistency, and expectations, especially in teams or large schemas.
+ *
+ * @author Ivan Vakhrushev
+ * @since 0.20.3
+ */
+public class TablesWherePrimaryKeyColumnsNotFirstCheckOnCluster extends AbstractCheckOnCluster<Table> {
+
+    public TablesWherePrimaryKeyColumnsNotFirstCheckOnCluster(final HighAvailabilityPgConnection haPgConnection) {
+        super(haPgConnection, TablesWherePrimaryKeyColumnsNotFirstCheckOnHost::new);
+    }
+}

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/AbstractCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/AbstractCheckOnClusterTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.core.fixtures.support.DatabaseAwareTestBase;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.IndexWithColumns;
 import io.github.mfvanek.pg.model.index.UnusedIndex;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -29,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @SuppressWarnings("checkstyle:AbstractClassName")
 class AbstractCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final AbstractCheckOnCluster<IndexWithColumns> check = new IndexesWithNullValuesCheckOnCluster(getHaPgConnection());
+    private final AbstractCheckOnCluster<@NonNull IndexWithColumns> check = new IndexesWithNullValuesCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldThrowExceptionIfMapperNotPassedForCrossClusterCheck() {
@@ -52,7 +53,7 @@ class AbstractCheckOnClusterTest extends DatabaseAwareTestBase {
         }
     }
 
-    static class WrongCheck extends AbstractCheckOnCluster<UnusedIndex> {
+    static class WrongCheck extends AbstractCheckOnCluster<@NonNull UnusedIndex> {
 
         WrongCheck(final HighAvailabilityPgConnection haPgConnection) {
             super(haPgConnection, UnusedIndexesCheckOnHost::new);

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/BtreeIndexesOnArrayColumnsCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/BtreeIndexesOnArrayColumnsCheckOnClusterTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.IndexWithColumns;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,7 +26,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class BtreeIndexesOnArrayColumnsCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<IndexWithColumns> check = new BtreeIndexesOnArrayColumnsCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull IndexWithColumns> check = new BtreeIndexesOnArrayColumnsCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ColumnsNotFollowingNamingConventionCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ColumnsNotFollowingNamingConventionCheckOnClusterTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.health.checks.common.DatabaseCheckOnCluster;
 import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -27,7 +28,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class ColumnsNotFollowingNamingConventionCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<Column> check = new ColumnsNotFollowingNamingConventionCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull Column> check = new ColumnsNotFollowingNamingConventionCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ColumnsWithFixedLengthVarcharCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ColumnsWithFixedLengthVarcharCheckOnClusterTest.java
@@ -16,6 +16,7 @@ import io.github.mfvanek.pg.core.fixtures.support.DatabasePopulator;
 import io.github.mfvanek.pg.health.checks.common.DatabaseCheckOnCluster;
 import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -24,7 +25,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class ColumnsWithFixedLengthVarcharCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<Column> check = new ColumnsWithFixedLengthVarcharCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull Column> check = new ColumnsWithFixedLengthVarcharCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ColumnsWithMoneyTypeCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ColumnsWithMoneyTypeCheckOnClusterTest.java
@@ -16,6 +16,7 @@ import io.github.mfvanek.pg.core.fixtures.support.DatabasePopulator;
 import io.github.mfvanek.pg.health.checks.common.DatabaseCheckOnCluster;
 import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -24,7 +25,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class ColumnsWithMoneyTypeCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<Column> check = new ColumnsWithMoneyTypeCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull Column> check = new ColumnsWithMoneyTypeCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ColumnsWithSerialTypesCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ColumnsWithSerialTypesCheckOnClusterTest.java
@@ -19,6 +19,7 @@ import io.github.mfvanek.pg.model.column.ColumnWithSerialType;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipBySequenceNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -29,7 +30,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class ColumnsWithSerialTypesCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<ColumnWithSerialType> check = new ColumnsWithSerialTypesCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull ColumnWithSerialType> check = new ColumnsWithSerialTypesCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ColumnsWithTimestampOrTimetzTypeCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ColumnsWithTimestampOrTimetzTypeCheckOnClusterTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.column.ColumnWithType;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -26,7 +27,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class ColumnsWithTimestampOrTimetzTypeCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<ColumnWithType> check = new ColumnsWithTimestampOrTimetzTypeCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull ColumnWithType> check = new ColumnsWithTimestampOrTimetzTypeCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ColumnsWithoutDescriptionCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ColumnsWithoutDescriptionCheckOnClusterTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.health.checks.common.DatabaseCheckOnCluster;
 import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -27,7 +28,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class ColumnsWithoutDescriptionCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<Column> check = new ColumnsWithoutDescriptionCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull Column> check = new ColumnsWithoutDescriptionCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ColumnsWithoutDescriptionCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ColumnsWithoutDescriptionCheckOnClusterTest.java
@@ -108,9 +108,10 @@ class ColumnsWithoutDescriptionCheckOnClusterTest extends DatabaseAwareTestBase 
         executeTestOnDatabase(schemaName, DatabasePopulator::withPartitionedTableWithoutComments, ctx ->
             assertThat(check)
                 .executing(ctx, SkipTablesByNamePredicate.of(ctx, List.of("accounts", "clients")))
-                .hasSize(4)
+                .hasSize(5)
                 .containsExactly(
                     Column.ofNotNull(ctx, expectedTableName, "creation_date"),
+                    Column.ofNullable(ctx, expectedTableName, "description"),
                     Column.ofNotNull(ctx, expectedTableName, "entity_id"),
                     Column.ofNotNull(ctx, expectedTableName, "ref_type"),
                     Column.ofNotNull(ctx, expectedTableName, "ref_value")));

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/DuplicatedForeignKeysCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/DuplicatedForeignKeysCheckOnClusterTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.model.constraint.DuplicatedForeignKeys;
 import io.github.mfvanek.pg.model.constraint.ForeignKey;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,7 +26,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class DuplicatedForeignKeysCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<DuplicatedForeignKeys> check = new DuplicatedForeignKeysCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull DuplicatedForeignKeys> check = new DuplicatedForeignKeysCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/DuplicatedIndexesCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/DuplicatedIndexesCheckOnClusterTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.index.DuplicatedIndexes;
 import io.github.mfvanek.pg.model.index.Index;
 import io.github.mfvanek.pg.model.predicates.SkipIndexesByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -26,7 +27,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class DuplicatedIndexesCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<DuplicatedIndexes> check = new DuplicatedIndexesCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull DuplicatedIndexes> check = new DuplicatedIndexesCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ForeignKeysNotCoveredWithIndexCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ForeignKeysNotCoveredWithIndexCheckOnClusterTest.java
@@ -19,6 +19,7 @@ import io.github.mfvanek.pg.model.constraint.ForeignKey;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipByConstraintNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -29,7 +30,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class ForeignKeysNotCoveredWithIndexCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<ForeignKey> check = new ForeignKeysNotCoveredWithIndexCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull ForeignKey> check = new ForeignKeysNotCoveredWithIndexCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ForeignKeysWithUnmatchedColumnTypeCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ForeignKeysWithUnmatchedColumnTypeCheckOnClusterTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.health.checks.common.DatabaseCheckOnCluster;
 import io.github.mfvanek.pg.model.constraint.ForeignKey;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,7 +26,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class ForeignKeysWithUnmatchedColumnTypeCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<ForeignKey> check = new ForeignKeysWithUnmatchedColumnTypeCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull ForeignKey> check = new ForeignKeysWithUnmatchedColumnTypeCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/FunctionsWithoutDescriptionCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/FunctionsWithoutDescriptionCheckOnClusterTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.health.checks.common.DatabaseCheckOnCluster;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.function.StoredFunction;
 import io.github.mfvanek.pg.model.predicates.SkipDbObjectsByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,7 +27,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class FunctionsWithoutDescriptionCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<StoredFunction> check = new FunctionsWithoutDescriptionCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull StoredFunction> check = new FunctionsWithoutDescriptionCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IndexesWithBloatCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IndexesWithBloatCheckOnClusterTest.java
@@ -21,6 +21,7 @@ import io.github.mfvanek.pg.model.predicates.SkipIndexesByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipSmallIndexesPredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import org.assertj.core.api.Assertions;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -31,7 +32,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class IndexesWithBloatCheckOnClusterTest extends StatisticsAwareTestBase {
 
-    private final DatabaseCheckOnCluster<IndexWithBloat> check = new IndexesWithBloatCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull IndexWithBloat> check = new IndexesWithBloatCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IndexesWithBooleanCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IndexesWithBooleanCheckOnClusterTest.java
@@ -19,6 +19,7 @@ import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.IndexWithColumns;
 import io.github.mfvanek.pg.model.predicates.SkipIndexesByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -27,7 +28,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class IndexesWithBooleanCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<IndexWithColumns> check = new IndexesWithBooleanCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull IndexWithColumns> check = new IndexesWithBooleanCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IndexesWithNullValuesCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IndexesWithNullValuesCheckOnClusterTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.IndexWithColumns;
 import io.github.mfvanek.pg.model.predicates.SkipIndexesByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -26,7 +27,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class IndexesWithNullValuesCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<IndexWithColumns> check = new IndexesWithNullValuesCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull IndexWithColumns> check = new IndexesWithNullValuesCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IndexesWithTimestampInTheMiddleCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IndexesWithTimestampInTheMiddleCheckOnClusterTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.IndexWithColumns;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class IndexesWithTimestampInTheMiddleCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<IndexWithColumns> check = new IndexesWithTimestampInTheMiddleCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull IndexWithColumns> check = new IndexesWithTimestampInTheMiddleCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IndexesWithUnnecessaryWhereClauseCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IndexesWithUnnecessaryWhereClauseCheckOnClusterTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.IndexWithColumns;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class IndexesWithUnnecessaryWhereClauseCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<IndexWithColumns> check = new IndexesWithUnnecessaryWhereClauseCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull IndexWithColumns> check = new IndexesWithUnnecessaryWhereClauseCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IntersectedForeignKeysCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IntersectedForeignKeysCheckOnClusterTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.constraint.DuplicatedForeignKeys;
 import io.github.mfvanek.pg.model.constraint.ForeignKey;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class IntersectedForeignKeysCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<DuplicatedForeignKeys> check = new IntersectedForeignKeysCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull DuplicatedForeignKeys> check = new IntersectedForeignKeysCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IntersectedIndexesCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IntersectedIndexesCheckOnClusterTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.index.DuplicatedIndexes;
 import io.github.mfvanek.pg.model.index.Index;
 import io.github.mfvanek.pg.model.predicates.SkipIndexesByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class IntersectedIndexesCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<DuplicatedIndexes> check = new IntersectedIndexesCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull DuplicatedIndexes> check = new IntersectedIndexesCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/InvalidIndexesCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/InvalidIndexesCheckOnClusterTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.Index;
 import io.github.mfvanek.pg.model.predicates.SkipIndexesByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,7 +26,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class InvalidIndexesCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<Index> check = new InvalidIndexesCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull Index> check = new InvalidIndexesCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/NotValidConstraintsCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/NotValidConstraintsCheckOnClusterTest.java
@@ -19,6 +19,7 @@ import io.github.mfvanek.pg.model.constraint.ConstraintType;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import org.assertj.core.api.Assertions;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -29,7 +30,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class NotValidConstraintsCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<Constraint> check = new NotValidConstraintsCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull Constraint> check = new NotValidConstraintsCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ObjectsNotFollowingNamingConventionCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ObjectsNotFollowingNamingConventionCheckOnClusterTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.dbobject.AnyObject;
 import io.github.mfvanek.pg.model.dbobject.PgObjectType;
 import io.github.mfvanek.pg.model.predicates.SkipDbObjectsByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class ObjectsNotFollowingNamingConventionCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<AnyObject> check = new ObjectsNotFollowingNamingConventionCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull AnyObject> check = new ObjectsNotFollowingNamingConventionCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/PossibleObjectNameOverflowCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/PossibleObjectNameOverflowCheckOnClusterTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.dbobject.AnyObject;
 import io.github.mfvanek.pg.model.dbobject.PgObjectType;
 import io.github.mfvanek.pg.model.predicates.SkipDbObjectsByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class PossibleObjectNameOverflowCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<AnyObject> check = new PossibleObjectNameOverflowCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull AnyObject> check = new PossibleObjectNameOverflowCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/PrimaryKeysThatMostLikelyNaturalKeysCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/PrimaryKeysThatMostLikelyNaturalKeysCheckOnClusterTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.IndexWithColumns;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class PrimaryKeysThatMostLikelyNaturalKeysCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<IndexWithColumns> check = new PrimaryKeysThatMostLikelyNaturalKeysCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull IndexWithColumns> check = new PrimaryKeysThatMostLikelyNaturalKeysCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/PrimaryKeysWithSerialTypesCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/PrimaryKeysWithSerialTypesCheckOnClusterTest.java
@@ -20,6 +20,7 @@ import io.github.mfvanek.pg.model.column.SerialType;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipBySequenceNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -30,7 +31,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class PrimaryKeysWithSerialTypesCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<ColumnWithSerialType> check = new PrimaryKeysWithSerialTypesCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull ColumnWithSerialType> check = new PrimaryKeysWithSerialTypesCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/PrimaryKeysWithVarcharCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/PrimaryKeysWithVarcharCheckOnClusterTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.column.Column;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.index.IndexWithColumns;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class PrimaryKeysWithVarcharCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<IndexWithColumns> check = new PrimaryKeysWithVarcharCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull IndexWithColumns> check = new PrimaryKeysWithVarcharCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/SequenceOverflowCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/SequenceOverflowCheckOnClusterTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.health.checks.common.DatabaseCheckOnCluster;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipBySequenceNamePredicate;
 import io.github.mfvanek.pg.model.sequence.SequenceState;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -27,7 +28,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class SequenceOverflowCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<SequenceState> check = new SequenceOverflowCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull SequenceState> check = new SequenceOverflowCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesNotLinkedToOthersCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesNotLinkedToOthersCheckOnClusterTest.java
@@ -16,6 +16,7 @@ import io.github.mfvanek.pg.health.checks.common.DatabaseCheckOnCluster;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import io.github.mfvanek.pg.model.table.Table;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -24,7 +25,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class TablesNotLinkedToOthersCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<Table> check = new TablesNotLinkedToOthersCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull Table> check = new TablesNotLinkedToOthersCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithBloatCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithBloatCheckOnClusterTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.predicates.SkipBloatUnderThresholdPredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import io.github.mfvanek.pg.model.table.TableWithBloat;
 import org.assertj.core.api.Assertions;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class TablesWithBloatCheckOnClusterTest extends StatisticsAwareTestBase {
 
-    private final DatabaseCheckOnCluster<TableWithBloat> check = new TablesWithBloatCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull TableWithBloat> check = new TablesWithBloatCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithMissingIndexesCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithMissingIndexesCheckOnClusterTest.java
@@ -19,6 +19,7 @@ import io.github.mfvanek.pg.model.predicates.SkipSmallTablesPredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import io.github.mfvanek.pg.model.table.TableWithMissingIndex;
 import org.assertj.core.api.Assertions;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -30,7 +31,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class TablesWithMissingIndexesCheckOnClusterTest extends StatisticsAwareTestBase {
 
-    private final DatabaseCheckOnCluster<TableWithMissingIndex> check = new TablesWithMissingIndexesCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull TableWithMissingIndex> check = new TablesWithMissingIndexesCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithZeroOrOneColumnCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithZeroOrOneColumnCheckOnClusterTest.java
@@ -17,6 +17,7 @@ import io.github.mfvanek.pg.health.checks.common.DatabaseCheckOnCluster;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import io.github.mfvanek.pg.model.table.TableWithColumns;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -27,7 +28,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class TablesWithZeroOrOneColumnCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<TableWithColumns> check = new TablesWithZeroOrOneColumnCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull TableWithColumns> check = new TablesWithZeroOrOneColumnCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithoutDescriptionCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithoutDescriptionCheckOnClusterTest.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipSmallTablesPredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import io.github.mfvanek.pg.model.table.Table;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +29,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class TablesWithoutDescriptionCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<Table> check = new TablesWithoutDescriptionCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull Table> check = new TablesWithoutDescriptionCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithoutPrimaryKeyCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithoutPrimaryKeyCheckOnClusterTest.java
@@ -16,6 +16,7 @@ import io.github.mfvanek.pg.health.checks.common.DatabaseCheckOnCluster;
 import io.github.mfvanek.pg.model.context.PgContext;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import io.github.mfvanek.pg.model.table.Table;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -24,7 +25,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class TablesWithoutPrimaryKeyCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<Table> check = new TablesWithoutPrimaryKeyCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull Table> check = new TablesWithoutPrimaryKeyCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/UnusedIndexesCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/UnusedIndexesCheckOnClusterTest.java
@@ -23,6 +23,7 @@ import io.github.mfvanek.pg.model.predicates.SkipDbObjectsByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipIndexesByNamePredicate;
 import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
 import org.assertj.core.api.Assertions;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -39,7 +40,7 @@ import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.a
 
 class UnusedIndexesCheckOnClusterTest extends DatabaseAwareTestBase {
 
-    private final DatabaseCheckOnCluster<UnusedIndex> check = new UnusedIndexesCheckOnCluster(getHaPgConnection());
+    private final DatabaseCheckOnCluster<@NonNull UnusedIndex> check = new UnusedIndexesCheckOnCluster(getHaPgConnection());
 
     @Test
     void shouldSatisfyContract() {

--- a/spring-boot-integration/pg-index-health-test-starter/src/main/java/io/github/mfvanek/pg/spring/DatabaseStructureChecksAutoConfiguration.java
+++ b/spring-boot-integration/pg-index-health-test-starter/src/main/java/io/github/mfvanek/pg/spring/DatabaseStructureChecksAutoConfiguration.java
@@ -40,6 +40,7 @@ import io.github.mfvanek.pg.core.checks.host.PrimaryKeysWithSerialTypesCheckOnHo
 import io.github.mfvanek.pg.core.checks.host.PrimaryKeysWithVarcharCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.SequenceOverflowCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesNotLinkedToOthersCheckOnHost;
+import io.github.mfvanek.pg.core.checks.host.TablesWherePrimaryKeyColumnsNotFirstCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithBloatCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithMissingIndexesCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithZeroOrOneColumnCheckOnHost;
@@ -308,6 +309,13 @@ public class DatabaseStructureChecksAutoConfiguration {
     @ConditionalOnMissingBean
     public ColumnsWithTimestampOrTimetzTypeCheckOnHost columnsWithTimestampOrTimetzTypeCheckOnHost(final PgConnection pgConnection) {
         return new ColumnsWithTimestampOrTimetzTypeCheckOnHost(pgConnection);
+    }
+
+    @Bean
+    @ConditionalOnClass(TablesWherePrimaryKeyColumnsNotFirstCheckOnHost.class)
+    @ConditionalOnMissingBean
+    public TablesWherePrimaryKeyColumnsNotFirstCheckOnHost tablesWherePrimaryKeyColumnsNotFirstCheckOnHost(final PgConnection pgConnection) {
+        return new TablesWherePrimaryKeyColumnsNotFirstCheckOnHost(pgConnection);
     }
 
     @Bean

--- a/spring-boot-integration/pg-index-health-test-starter/src/test/java/io/github/mfvanek/pg/spring/AutoConfigurationTestBase.java
+++ b/spring-boot-integration/pg-index-health-test-starter/src/test/java/io/github/mfvanek/pg/spring/AutoConfigurationTestBase.java
@@ -41,6 +41,7 @@ import io.github.mfvanek.pg.core.checks.host.PrimaryKeysWithSerialTypesCheckOnHo
 import io.github.mfvanek.pg.core.checks.host.PrimaryKeysWithVarcharCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.SequenceOverflowCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesNotLinkedToOthersCheckOnHost;
+import io.github.mfvanek.pg.core.checks.host.TablesWherePrimaryKeyColumnsNotFirstCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithBloatCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithMissingIndexesCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithZeroOrOneColumnCheckOnHost;
@@ -152,7 +153,8 @@ abstract class AutoConfigurationTestBase {
             PrimaryKeysThatMostLikelyNaturalKeysCheckOnHost.class,
             ColumnsWithMoneyTypeCheckOnHost.class,
             IndexesWithTimestampInTheMiddleCheckOnHost.class,
-            ColumnsWithTimestampOrTimetzTypeCheckOnHost.class
+            ColumnsWithTimestampOrTimetzTypeCheckOnHost.class,
+            TablesWherePrimaryKeyColumnsNotFirstCheckOnHost.class
         );
     }
 }


### PR DESCRIPTION
Closes https://github.com/mfvanek/pg-index-health/issues/634