### PR TITLE
Add ArchUnit tests for auto-configuration

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ detekt = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin",
 liquibase-core = "org.liquibase:liquibase-core:5.0.1"
 liquibase-sessionlock = "com.github.blagerweij:liquibase-sessionlock:1.6.9"
 junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit" }
+arch-unit = "com.tngtech.archunit:archunit-junit5:1.4.1"
 
 [plugins]
 spring-boot-v3-gradle-plugin = { id = "org.springframework.boot", version.ref = "spring-boot-v3" }

--- a/pg-index-health-core/build.gradle.kts
+++ b/pg-index-health-core/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     testImplementation(libs.postgresql)
     testImplementation(libs.slf4j.simple)
     testImplementation(libs.slf4j.jul)
+    testImplementation(libs.arch.unit)
 
     testFixturesImplementation(libs.jspecify)
     testFixturesImplementation(libs.apache.commons.lang3)

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/statistics/StatisticsMaintenanceOnHost.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/statistics/StatisticsMaintenanceOnHost.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 public interface StatisticsMaintenanceOnHost extends StatisticsAware, HostAware {
 
     /**
-     * Resets all statistics counters for the current database on current host to zero.
+     * Resets all statistics counters for the current database on the current host to zero.
      * <p>
      * Note: superuser privileges are required.
      *
@@ -35,7 +35,7 @@ public interface StatisticsMaintenanceOnHost extends StatisticsAware, HostAware 
     boolean resetStatistics();
 
     /**
-     * Retrieves the time at which database statistics were last reset on current host.
+     * Retrieves the time at which database statistics were last reset on the current host.
      *
      * @return {@code Optional} of null or time at which database statistics were last reset.
      */

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/ArchitectureTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/ArchitectureTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019-2025. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.core;
+
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import io.github.mfvanek.pg.core.checks.common.ResultSetExtractor;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+@AnalyzeClasses(packages = "io.github.mfvanek.pg.core")
+class ArchitectureTest {
+
+    @ArchTest
+    static final ArchRule ALL_EXTRACTORS_SHOULD_BE_FINAL =
+        classes().that().areNotInterfaces().and().implement(ResultSetExtractor.class)
+            .should().haveOnlyFinalFields()
+            .andShould().haveOnlyPrivateConstructors()
+            .andShould().haveModifier(JavaModifier.FINAL);
+}

--- a/pg-index-health-model/build.gradle.kts
+++ b/pg-index-health-model/build.gradle.kts
@@ -9,6 +9,7 @@ description = "pg-index-health-model is a set of common classes and interfaces f
 dependencies {
     testImplementation(libs.equalsverifier)
     testImplementation("org.mockito:mockito-core")
+    testImplementation(libs.arch.unit)
 
     testFixturesImplementation(libs.jspecify)
     testFixturesCompileOnly(libs.forbiddenapis)

--- a/pg-index-health-model/src/test/java/io/github/mfvanek/pg/model/ArchitectureTest.java
+++ b/pg-index-health-model/src/test/java/io/github/mfvanek/pg/model/ArchitectureTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019-2025. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.model;
+
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+@AnalyzeClasses(packages = "io.github.mfvanek.pg.model")
+class ArchitectureTest {
+
+    @ArchTest
+    static final ArchRule ALL_PUBLIC_CLASSES_SHOULD_BE_FINAL =
+        classes().that().areNotInterfaces().and().arePublic()
+            .should().haveOnlyFinalFields()
+            .andShould().haveOnlyPrivateConstructors()
+            .andShould().haveModifier(JavaModifier.FINAL);
+}

--- a/spring-boot-integration/pg-index-health-test-starter/build.gradle.kts
+++ b/spring-boot-integration/pg-index-health-test-starter/build.gradle.kts
@@ -28,4 +28,5 @@ dependencies {
     testImplementation(libs.spring.boot.v3.starter.test)
     testImplementation(libs.apache.commons.lang3)
     testImplementation(libs.postgresql)
+    testImplementation(libs.arch.unit)
 }

--- a/spring-boot-integration/pg-index-health-test-starter/src/test/java/io/github/mfvanek/pg/spring/ArchitectureTest.java
+++ b/spring-boot-integration/pg-index-health-test-starter/src/test/java/io/github/mfvanek/pg/spring/ArchitectureTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019-2025. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.spring;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import io.github.mfvanek.pg.core.checks.common.DatabaseCheckOnHost;
+import io.github.mfvanek.pg.core.checks.host.AbstractCheckOnHost;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+@AnalyzeClasses(packages = "io.github.mfvanek.pg.spring")
+class ArchitectureTest {
+
+    @ArchTest
+    static final ArchRule AUTOCONFIGURED_BEANS_ARE_ANNOTATED_WITH_ANY_CONDITIONAL_ANNOTATION =
+        methods().that().areAnnotatedWith(Bean.class)
+            .and().areDeclaredInClassesThat().areMetaAnnotatedWith(AutoConfiguration.class)
+            .should().beAnnotatedWith(ConditionalOnMissingBean.class)
+            .as("Auto-configuration beans should be annotated with any @Conditional annotation")
+            .because("Spring Framework should not create those beans if an application already declared beans of the same type");
+
+    @ArchTest
+    static final ArchRule CHECK_BEANS_SHOULD_USE_CONCRETE_TYPES_AS_RETURN_TYPES =
+        methods().that().areAnnotatedWith(Bean.class)
+            .should().notHaveRawReturnType(AbstractCheckOnHost.class)
+            .andShould().notHaveRawReturnType(DatabaseCheckOnHost.class);
+}


### PR DESCRIPTION
Closes https://github.com/mfvanek/pg-index-health/issues/756

### Common steps

- [x] Read [CONTRIBUTING.md](https://github.com/mfvanek/pg-index-health/blob/master/CONTRIBUTING.md)
- [x] Linked to an issue
- [ ] Added a description to PR

### For a database check

- [ ] I have updated the [list of checks](https://github.com/mfvanek/pg-index-health/blob/master/doc/available_checks.md)
- [ ] I have added the same tests for a check on host and a check on cluster
- [ ] The check results are validated with `containsExactly()` and `usingRecursiveFieldByFieldElementComparator()`

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
