### PR TITLE
Add a new check "Multicolumn foreign keys with nulls"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ After your PR with a new SQL query is merged, you need to update the git submodu
 
 ### Extend the domain model (if needed)
 
-pg-index-health is a [multimodule Gradle](https://docs.gradle.org/current/userguide/multi_project_builds.html) project.  
+`pg-index-health` is a [multimodule Gradle](https://docs.gradle.org/current/userguide/multi_project_builds.html) project.  
 Domain model is located in a [pg-index-health-model](pg-index-health-model).
 
 Best practices:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 plugins {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
 plugins {
     `kotlin-dsl`
 }

--- a/doc/available_checks.md
+++ b/doc/available_checks.md
@@ -51,6 +51,7 @@ All checks can be divided into two groups:
 | 37 | Tables that have all columns besides the primary key that are nullable                                                             | static             | yes                   | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_where_all_columns_nullable_except_pk.sql) |
 | 38 | Columns with [char(n) type](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don't_use_char(n))                                    | static             | yes                   | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_char_type.sql)                      |
 | 39 | Tables with [inheritance](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_table_inheritance)                          | static             | not applicable        | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_inheritance.sql)                     |
+| 40 | Multicolumn foreign keys where at least one of the referencing columns is nullable                                                 | static             | yes                   | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/foreign_keys_with_null_values.sql)               |
 
 ### Raw SQL queries to use with other languages
 

--- a/doc/eng/foreign_keys_with_null_values.md
+++ b/doc/eng/foreign_keys_with_null_values.md
@@ -1,0 +1,96 @@
+# Check for composite (multi-column) foreign keys with nullable columns that are not defined with `MATCH FULL`
+
+If a foreign key spans multiple columns (a composite foreign key) and some of those columns are nullable,
+it becomes possible to insert rows into the referencing table that do not exist in the referenced table.
+
+By default, PostgreSQL creates foreign keys using the `MATCH SIMPLE` option.
+This allows any column in the foreign key to be `NULL`.
+If at least one column is `NULL`, PostgreSQL does not require a matching row in the referenced table.
+
+The `MATCH FULL` option changes this behavior.
+It requires that either all columns of the foreign key are `NULL`, or none of them are.
+In other words, partial `NULL` values are not allowed.
+
+See details in the [official documentation](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK)
+and [this Habr article](https://habr.com/ru/articles/803841/).
+
+## SQL query
+
+- [foreign_keys_with_null_values.sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/foreign_keys_with_null_values.sql)
+
+## Check type
+
+- **static** (can be performed on an empty database in component/integration tests)
+
+## Support for partitioned tables
+
+Supports partitioned tables.
+The check is performed on the partitioned table itself (the parent one). Individual sections (descendants) are ignored.
+
+## Reproduction script
+
+```sql
+create schema if not exists demo;
+
+create table demo.referenced_table
+(
+    id    int not null,
+    value text not null,
+    primary key (id, value)
+);
+
+-- Filling with data
+insert into demo.referenced_table (id, value) values (10, '10');
+insert into demo.referenced_table (id, value) values (20, '20');
+
+create table demo.referencing_bad_table
+(
+    rbt_id integer not null,
+    rbt_value text, -- nullable
+    constraint "referencing-bad-table-fk" foreign key (rbt_id, rbt_value)
+        references demo.referenced_table (id, value)
+);
+
+-- Since the rbt_value field can contain null, both records will be added to the table.
+-- If the constraint referencing_bad_table_fk had been set to MATCH FULL, the second entry would not have been added.
+-- https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK
+insert into demo.referencing_bad_table (rbt_id, rbt_value) values (20, '20');
+insert into demo.referencing_bad_table (rbt_id, rbt_value) values (30, null);
+
+table demo.referencing_bad_table;
+
+create table demo.referencing_good_table
+(
+    rgt_id integer not null,
+    rgt_value text, -- nullable
+    constraint referencing_good_table_fk foreign key (rgt_id, rgt_value)
+        references demo.referenced_table (id, value) match full
+);
+
+insert into demo.referencing_good_table (rgt_id, rgt_value) values (20, '20');
+-- insert into demo.referencing_good_table (rgt_id, rgt_value) values (30, null); -- error!
+
+table demo.referencing_good_table;
+
+-- For partitioned tables
+
+create table if not exists demo.referencing_bad_table_partitioned(
+    rbt_id integer not null,
+    rbt_value text, -- nullable
+    created_at timestamptz not null default current_timestamp,
+    constraint "referencing_bad_table_partitioned-fk" foreign key (rbt_id, rbt_value)
+        references demo.referenced_table (id, value)
+) partition by range (created_at);
+
+create table if not exists demo.referencing_bad_table_default
+    partition of demo.referencing_bad_table_partitioned default;
+
+insert into demo.referencing_bad_table_partitioned (rbt_id, rbt_value) values (20, '20');
+insert into demo.referencing_bad_table_partitioned (rbt_id, rbt_value) values (30, null);
+
+table demo.referencing_bad_table_partitioned;
+```
+
+## How to fix
+
+For composite foreign keys containing nullable columns, use the `MATCH FULL` option.

--- a/doc/rus/foreign_keys_with_null_values.md
+++ b/doc/rus/foreign_keys_with_null_values.md
@@ -1,0 +1,97 @@
+# Проверка внешних ключей,
+
+Если внешний ключ состоит из нескольких колонок, и часть из них может принимать значение `NULL`,
+то в эту таблицу могут добавляться данные, которые отсутсвуют в целевой (referenced) таблице.
+
+Дело в том, что PostgreSQL по умолчанию создаёт внешние ключи с опцией `MATCH SIMPLE`,
+которая допускает, чтобы любой из столбцов внешнего ключа был `NULL`.
+И если хотя бы один из них `NULL`, строка не обязана иметь соответствие в целевой таблице.
+
+Исправить такое поведение позволяет опция `MATCH FULL`.
+Она не допускает, чтобы один столбец составного внешнего ключа был `NULL`,
+если только все столбцы внешнего ключа не `NULL`.
+
+Подробности в [официальной документации](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK)
+и [статье на Хабре](https://habr.com/ru/articles/803841/).
+
+## SQL запрос
+
+- [foreign_keys_with_null_values.sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/foreign_keys_with_null_values.sql)
+
+## Тип проверки
+
+- **static** (может выполняться на пустой БД в компонентных\интеграционных тестах)
+
+## Поддержка секционированных таблиц
+
+Поддерживает секционированные таблицы.
+Проверка выполняется на самой секционированной таблице (родительской). Отдельные секции (потомки) игнорируются.
+
+## Скрипт для воспроизведения
+
+```sql
+create schema if not exists demo;
+
+create table demo.referenced_table
+(
+    id    int not null,
+    value text not null,
+    primary key (id, value)
+);
+
+-- Заполнение справочника
+insert into demo.referenced_table (id, value) values (10, '10');
+insert into demo.referenced_table (id, value) values (20, '20');
+
+create table demo.referencing_bad_table
+(
+    rbt_id integer not null,
+    rbt_value text, -- nullable
+    constraint "referencing-bad-table-fk" foreign key (rbt_id, rbt_value)
+        references demo.referenced_table (id, value)
+);
+
+-- Добавление данных
+-- Из-за того, что поле rbt_value может содержать null, обе записи будут добавлены в таблицу.
+-- Если бы для constraint referencing_bad_table_fk установили match full, то вторая запись не была бы добавлена.
+-- https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK
+insert into demo.referencing_bad_table (rbt_id, rbt_value) values (20, '20');
+insert into demo.referencing_bad_table (rbt_id, rbt_value) values (30, null);
+
+table demo.referencing_bad_table;
+
+create table demo.referencing_good_table
+(
+    rgt_id integer not null,
+    rgt_value text, -- nullable
+    constraint referencing_good_table_fk foreign key (rgt_id, rgt_value)
+        references demo.referenced_table (id, value) match full
+);
+
+insert into demo.referencing_good_table (rgt_id, rgt_value) values (20, '20');
+-- insert into demo.referencing_good_table (rgt_id, rgt_value) values (30, null); -- error!
+
+table demo.referencing_good_table;
+
+-- Для секционированных таблиц
+
+create table if not exists demo.referencing_bad_table_partitioned(
+    rbt_id integer not null,
+    rbt_value text, -- nullable
+    created_at timestamptz not null default current_timestamp,
+    constraint "referencing_bad_table_partitioned-fk" foreign key (rbt_id, rbt_value)
+        references demo.referenced_table (id, value)
+) partition by range (created_at);
+
+create table if not exists demo.referencing_bad_table_default
+    partition of demo.referencing_bad_table_partitioned default;
+
+insert into demo.referencing_bad_table_partitioned (rbt_id, rbt_value) values (20, '20');
+insert into demo.referencing_bad_table_partitioned (rbt_id, rbt_value) values (30, null);
+
+table demo.referencing_bad_table_partitioned;
+```
+
+## Как исправить
+
+Для составных внешних ключей, содержащих nullable колонки, используйте опцию `MATCH FULL`.

--- a/doc/rus/foreign_keys_with_null_values.md
+++ b/doc/rus/foreign_keys_with_null_values.md
@@ -1,4 +1,4 @@
-# Проверка внешних ключей,
+# Проверка наличия составных внешних ключей с nullable колонками без опции `MATCH FULL`
 
 Если внешний ключ состоит из нескольких колонок, и часть из них может принимать значение `NULL`,
 то в эту таблицу могут добавляться данные, которые отсутсвуют в целевой (referenced) таблице.
@@ -53,7 +53,7 @@ create table demo.referencing_bad_table
 
 -- Добавление данных
 -- Из-за того, что поле rbt_value может содержать null, обе записи будут добавлены в таблицу.
--- Если бы для constraint referencing_bad_table_fk установили match full, то вторая запись не была бы добавлена.
+-- Если бы для constraint referencing_bad_table_fk установили MATCH FULL, то вторая запись не была бы добавлена.
 -- https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK
 insert into demo.referencing_bad_table (rbt_id, rbt_value) values (20, '20');
 insert into demo.referencing_bad_table (rbt_id, rbt_value) values (30, null);

--- a/jackson-integration/pg-index-health-model-jackson2-module/build.gradle.kts
+++ b/jackson-integration/pg-index-health-model-jackson2-module/build.gradle.kts
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
 plugins {
     id("pg-index-health.java-library")
     id("pg-index-health.pitest")

--- a/jackson-integration/pg-index-health-model-jackson2-module/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
+++ b/jackson-integration/pg-index-health-model-jackson2-module/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
@@ -1,1 +1,11 @@
+#
+# Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+# https://github.com/mfvanek/pg-index-health
+#
+# This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+# that detects common anti-patterns and promotes best practices.
+#
+# Licensed under the Apache License 2.0
+#
+
 io.github.mfvanek.pg.model.jackson2.PgIndexHealthModelModule

--- a/jackson-integration/pg-index-health-model-jackson3-module/build.gradle.kts
+++ b/jackson-integration/pg-index-health-model-jackson3-module/build.gradle.kts
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
 plugins {
     id("pg-index-health.java-library")
     id("pg-index-health.pitest")

--- a/jackson-integration/pg-index-health-model-jackson3-module/src/main/resources/META-INF/services/tools.jackson.databind.JacksonModule
+++ b/jackson-integration/pg-index-health-model-jackson3-module/src/main/resources/META-INF/services/tools.jackson.databind.JacksonModule
@@ -1,1 +1,11 @@
+#
+# Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+# https://github.com/mfvanek/pg-index-health
+#
+# This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+# that detects common anti-patterns and promotes best practices.
+#
+# Licensed under the Apache License 2.0
+#
+
 io.github.mfvanek.pg.model.jackson3.PgIndexHealthModelModule

--- a/pg-index-health-bom/build.gradle.kts
+++ b/pg-index-health-bom/build.gradle.kts
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
 import com.vanniktech.maven.publish.JavaPlatform
 
 plugins {

--- a/pg-index-health-core/build.gradle.kts
+++ b/pg-index-health-core/build.gradle.kts
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
 plugins {
     id("pg-index-health.java-library")
     id("pg-index-health.mandatory-javadoc")

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/Diagnostic.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/Diagnostic.java
@@ -22,14 +22,15 @@ import java.util.function.Function;
  * @see QueryExecutor
  * @see QueryExecutors
  */
+@SuppressWarnings("PMD.ExcessivePublicCount")
 public enum Diagnostic implements CheckInfo {
 
     /**
-     * Check for indexes bloat.
+     * Check for index bloat.
      */
     BLOATED_INDEXES(StandardCheckInfo::ofBloat),
     /**
-     * Check for tables bloat.
+     * Check for table bloat.
      */
     BLOATED_TABLES(StandardCheckInfo::ofBloat),
     /**

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/Diagnostic.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/Diagnostic.java
@@ -179,7 +179,11 @@ public enum Diagnostic implements CheckInfo {
     /**
      * Check for tables with inheritance.
      */
-    TABLES_WITH_INHERITANCE;
+    TABLES_WITH_INHERITANCE,
+    /**
+     * Check for composite (multi-column) foreign keys with nullable columns that are not defined with MATCH FULL.
+     */
+    FOREIGN_KEYS_WITH_NULL_VALUES;
 
     private final CheckInfo inner;
 

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/ForeignKeysWithNullValuesCheckOnHost.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/ForeignKeysWithNullValuesCheckOnHost.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.core.checks.host;
+
+import io.github.mfvanek.pg.connection.PgConnection;
+import io.github.mfvanek.pg.core.checks.common.Diagnostic;
+import io.github.mfvanek.pg.core.checks.extractors.ForeignKeyExtractor;
+import io.github.mfvanek.pg.model.constraint.ForeignKey;
+import io.github.mfvanek.pg.model.context.PgContext;
+
+import java.util.List;
+
+/**
+ * Check for composite (multi-column) foreign keys with nullable columns
+ * that are not defined with MATCH FULL on a specific host.
+ *
+ * @author Ivan Vakhrushev
+ * @since 0.41.0
+ */
+public class ForeignKeysWithNullValuesCheckOnHost extends AbstractCheckOnHost<ForeignKey> {
+
+    /**
+     * Constructs a new instance of {@code ForeignKeysWithNullValuesCheckOnHost}.
+     *
+     * @param pgConnection the connection to the PostgreSQL database; must not be null
+     */
+    public ForeignKeysWithNullValuesCheckOnHost(final PgConnection pgConnection) {
+        super(ForeignKey.class, pgConnection, Diagnostic.FOREIGN_KEYS_WITH_NULL_VALUES);
+    }
+
+    /**
+     * Returns composite (multi-column) foreign keys with nullable columns
+     * that are not defined with MATCH FULL in the specified schema.
+     *
+     * @param pgContext check's context with the specified schema
+     * @return list of composite (multi-column) foreign keys with nullable columns
+     */
+    @Override
+    protected List<ForeignKey> doCheck(final PgContext pgContext) {
+        return executeQuery(pgContext, ForeignKeyExtractor.ofDefault());
+    }
+}

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/StandardChecksOnHost.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/StandardChecksOnHost.java
@@ -81,7 +81,8 @@ public final class StandardChecksOnHost implements Function<PgConnection, List<D
             new TablesWherePrimaryKeyColumnsNotFirstCheckOnHost(pgConnection),
             new TablesWhereAllColumnsNullableExceptPrimaryKeyCheckOnHost(pgConnection),
             new ColumnsWithCharTypeCheckOnHost(pgConnection),
-            new TablesWithInheritanceCheckOnHost(pgConnection)
+            new TablesWithInheritanceCheckOnHost(pgConnection),
+            new ForeignKeysWithNullValuesCheckOnHost(pgConnection)
         );
     }
 }

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ForeignKeysWithNullValuesCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ForeignKeysWithNullValuesCheckOnHostTest.java
@@ -8,12 +8,10 @@
  * Licensed under the Apache License 2.0
  */
 
-rootProject.name = "pg-index-health-conventions"
+package io.github.mfvanek.pg.core.checks.host;
 
-dependencyResolutionManagement {
-    versionCatalogs {
-        create("libs") {
-            from(files("../gradle/libs.versions.toml"))
-        }
-    }
+import static org.junit.jupiter.api.Assertions.*;
+
+class ForeignKeysWithNullValuesCheckOnHostTest {
+
 }

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ForeignKeysWithNullValuesCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ForeignKeysWithNullValuesCheckOnHostTest.java
@@ -10,8 +10,71 @@
 
 package io.github.mfvanek.pg.core.checks.host;
 
-import static org.junit.jupiter.api.Assertions.*;
+import io.github.mfvanek.pg.core.checks.common.DatabaseCheckOnHost;
+import io.github.mfvanek.pg.core.checks.common.Diagnostic;
+import io.github.mfvanek.pg.core.fixtures.support.DatabaseAwareTestBase;
+import io.github.mfvanek.pg.core.fixtures.support.DatabasePopulator;
+import io.github.mfvanek.pg.model.column.Column;
+import io.github.mfvanek.pg.model.constraint.ForeignKey;
+import io.github.mfvanek.pg.model.context.PgContext;
+import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-class ForeignKeysWithNullValuesCheckOnHostTest {
+import java.util.List;
 
+import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assertThat;
+
+class ForeignKeysWithNullValuesCheckOnHostTest extends DatabaseAwareTestBase {
+
+    private final DatabaseCheckOnHost<@NonNull ForeignKey> check = new ForeignKeysWithNullValuesCheckOnHost(getPgConnection());
+
+    @Test
+    void shouldSatisfyContract() {
+        assertThat(check)
+            .hasType(ForeignKey.class)
+            .hasDiagnostic(Diagnostic.FOREIGN_KEYS_WITH_NULL_VALUES)
+            .hasHost(getHost())
+            .isStatic();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
+    void onDatabaseWithThem(final String schemaName) {
+        executeTestOnDatabase(schemaName, dbp -> dbp.withReferences().withForeignKeyOnNullableColumn().withCompositeForeignKey(), ctx -> {
+            final String tableName = "referencing_bad_table";
+            assertThat(check)
+                .executing(ctx)
+                .hasSize(2)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(
+                    ForeignKey.of(ctx, "bad_clients", "c_bad_clients_fk_email_phone", List.of(
+                        Column.ofNullable(ctx, "bad_clients", "email"),
+                        Column.ofNullable(ctx, "bad_clients", "phone"))),
+                    ForeignKey.of(ctx, tableName, "\"referencing-bad-table-fk\"", List.of(
+                        Column.ofNotNull(ctx, tableName, "rbt_id"),
+                        Column.ofNullable(ctx, tableName, "rbt_value")
+                    ))
+                );
+
+            assertThat(check)
+                .executing(ctx, SkipTablesByNamePredicate.of(ctx, List.of(tableName, "bad_clients")))
+                .isEmpty();
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
+    void shouldWorkWithPartitionedTables(final String schemaName) {
+        executeTestOnDatabase(schemaName, DatabasePopulator::withSerialAndForeignKeysInPartitionedTable, ctx ->
+            assertThat(check)
+                .executing(ctx)
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(
+                    ForeignKey.ofNotNullColumn(ctx, "t1", "t1_ref_type_fkey", "ref_type")
+                ));
+    }
 }

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ForeignKeysWithNullValuesCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/ForeignKeysWithNullValuesCheckOnHostTest.java
@@ -68,13 +68,18 @@ class ForeignKeysWithNullValuesCheckOnHostTest extends DatabaseAwareTestBase {
     @ParameterizedTest
     @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
     void shouldWorkWithPartitionedTables(final String schemaName) {
-        executeTestOnDatabase(schemaName, DatabasePopulator::withSerialAndForeignKeysInPartitionedTable, ctx ->
+        executeTestOnDatabase(schemaName, DatabasePopulator::withCompositeForeignKeyInPartitionedTable, ctx -> {
+            final String tableName = "referencing_bad_table_partitioned";
             assertThat(check)
                 .executing(ctx)
                 .hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(
-                    ForeignKey.ofNotNullColumn(ctx, "t1", "t1_ref_type_fkey", "ref_type")
-                ));
+                    ForeignKey.of(ctx, tableName, "\"referencing_bad_table_partitioned-fk\"", List.of(
+                        Column.ofNotNull(ctx, tableName, "rbt_id"),
+                        Column.ofNullable(ctx, tableName, "rbt_value")
+                    ))
+                );
+        });
     }
 }

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IntersectedIndexesCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IntersectedIndexesCheckOnHostTest.java
@@ -108,9 +108,12 @@ class IntersectedIndexesCheckOnHostTest extends DatabaseAwareTestBase {
         executeTestOnDatabase(schemaName, dbp -> dbp.withSerialAndForeignKeysInPartitionedTable().withDuplicatedAndIntersectedIndexesInPartitionedTable(), ctx ->
             assertThat(check)
                 .executing(ctx)
-                .hasSize(2)
+                .hasSize(3)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(
+                    DuplicatedIndexes.of(
+                        Index.of(ctx, "dict", "dict_pkey", 16_384L),
+                        Index.of(ctx, "dict", "idx_dict_ref_type_ref_value", 16_384L)),
                     DuplicatedIndexes.of(
                         Index.of(ctx, "t1", "idx_t1_deleted_duplicate"),
                         Index.of(ctx, "t1", "idx_t1_deleted_entity_id")),

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
@@ -382,17 +382,17 @@ public final class DatabasePopulator implements AutoCloseable {
     }
 
     public DatabasePopulator withDictTable() {
-        return register(147, new CreateDictTableStatement());
+        return register(31, new CreateDictTableStatement());
     }
 
     public DatabasePopulator withCompositeForeignKey() {
         return withDictTable()
-            .register(148, new AddCompositeForeignKeyWithNullValuesStatement());
+            .register(147, new AddCompositeForeignKeyWithNullValuesStatement());
     }
 
     public DatabasePopulator withCompositeForeignKeyInPartitionedTable() {
         return withDictTable()
-            .register(149, new AddCompositeForeignKeyWithNullValuesToPartitionedTableStatement());
+            .register(148, new AddCompositeForeignKeyWithNullValuesToPartitionedTableStatement());
     }
 
     public void populate() {

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
@@ -18,6 +18,7 @@ import io.github.mfvanek.pg.core.fixtures.support.statements.AddCommentOnColumns
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddCommentOnFunctionsStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddCommentOnProceduresStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddCommentOnTablesStatement;
+import io.github.mfvanek.pg.core.fixtures.support.statements.AddCompositeForeignKeyWithNullValuesStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddDuplicatedForeignKeysStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddDuplicatedForeignKeysToPartitionedTableStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddIntersectedForeignKeysStatement;
@@ -33,6 +34,7 @@ import io.github.mfvanek.pg.core.fixtures.support.statements.CreateBadlyNamedObj
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreateBadlyNamedPartitionedTableStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreateClientsTableStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreateCustomCollationStatement;
+import io.github.mfvanek.pg.core.fixtures.support.statements.CreateDictTableStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreateDuplicatedAndIntersectedIndexesInPartitionedTableStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreateDuplicatedCustomCollationIndexStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreateDuplicatedHashIndexStatement;
@@ -292,7 +294,8 @@ public final class DatabasePopulator implements AutoCloseable {
     }
 
     public DatabasePopulator withSerialAndForeignKeysInPartitionedTable() {
-        return register(116, new CreatePartitionedTableWithSerialAndForeignKeysStatement());
+        return withDictTable()
+            .register(116, new CreatePartitionedTableWithSerialAndForeignKeysStatement());
     }
 
     public DatabasePopulator withDuplicatedAndIntersectedIndexesInPartitionedTable() {
@@ -308,11 +311,13 @@ public final class DatabasePopulator implements AutoCloseable {
     }
 
     public DatabasePopulator withDuplicatedForeignKeysInPartitionedTable() {
-        return register(120, new AddDuplicatedForeignKeysToPartitionedTableStatement());
+        return withDictTable()
+            .register(120, new AddDuplicatedForeignKeysToPartitionedTableStatement());
     }
 
     public DatabasePopulator withIntersectedForeignKeysInPartitionedTable() {
-        return register(121, new AddIntersectedForeignKeysToPartitionedTableStatement());
+        return withDictTable()
+            .register(121, new AddIntersectedForeignKeysToPartitionedTableStatement());
     }
 
     public DatabasePopulator withDroppedColumnInPartitionedTable() {
@@ -373,6 +378,15 @@ public final class DatabasePopulator implements AutoCloseable {
 
     public DatabasePopulator withInheritance() {
         return register(146, new CreateTableWithInheritanceStatement());
+    }
+
+    public DatabasePopulator withDictTable() {
+        return register(147, new CreateDictTableStatement());
+    }
+
+    public DatabasePopulator withCompositeForeignKey() {
+        return withDictTable()
+            .register(148, new AddCompositeForeignKeyWithNullValuesStatement());
     }
 
     public void populate() {

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
@@ -19,6 +19,7 @@ import io.github.mfvanek.pg.core.fixtures.support.statements.AddCommentOnFunctio
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddCommentOnProceduresStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddCommentOnTablesStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddCompositeForeignKeyWithNullValuesStatement;
+import io.github.mfvanek.pg.core.fixtures.support.statements.AddCompositeForeignKeyWithNullValuesToPartitionedTableStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddDuplicatedForeignKeysStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddDuplicatedForeignKeysToPartitionedTableStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddIntersectedForeignKeysStatement;
@@ -387,6 +388,11 @@ public final class DatabasePopulator implements AutoCloseable {
     public DatabasePopulator withCompositeForeignKey() {
         return withDictTable()
             .register(148, new AddCompositeForeignKeyWithNullValuesStatement());
+    }
+
+    public DatabasePopulator withCompositeForeignKeyInPartitionedTable() {
+        return withDictTable()
+            .register(149, new AddCompositeForeignKeyWithNullValuesToPartitionedTableStatement());
     }
 
     public void populate() {

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/AddCompositeForeignKeyWithNullValuesStatement.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/AddCompositeForeignKeyWithNullValuesStatement.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.core.fixtures.support.statements;
+
+import java.util.List;
+
+public class AddCompositeForeignKeyWithNullValuesStatement extends AbstractDbStatement {
+
+    @Override
+    protected List<String> getSqlToExecute() {
+        return List.of(
+            """
+                create table {schemaName}.referencing_bad_table (
+                    rbt_id integer not null,
+                    rbt_value text, /* nullable */
+                    constraint "referencing-bad-table-fk" foreign key (rbt_id, rbt_value)
+                        references {schemaName}.dict (ref_type, ref_value)
+                );""",
+            "insert into {schemaName}.referencing_bad_table (rbt_id, rbt_value) values (20, '20');",
+            "insert into {schemaName}.referencing_bad_table (rbt_id, rbt_value) values (30, null);",
+            """
+                create table {schemaName}.referencing_good_table (
+                    rgt_id integer not null,
+                    rgt_value text, -- nullable
+                    constraint referencing_good_table_fk foreign key (rgt_id, rgt_value)
+                        references {schemaName}.dict (ref_type, ref_value) match full
+                );""",
+            "insert into {schemaName}.referencing_good_table (rgt_id, rgt_value) values (20, '20');"
+        );
+    }
+}

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/AddCompositeForeignKeyWithNullValuesToPartitionedTableStatement.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/AddCompositeForeignKeyWithNullValuesToPartitionedTableStatement.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.core.fixtures.support.statements;
+
+import java.util.List;
+
+public class AddCompositeForeignKeyWithNullValuesToPartitionedTableStatement extends AbstractDbStatement {
+
+    @Override
+    protected List<String> getSqlToExecute() {
+        return List.of(
+            """
+                create table if not exists {schemaName}.referencing_bad_table_partitioned(
+                    rbt_id integer not null,
+                    rbt_value text, /* nullable */
+                    created_at timestamptz not null default current_timestamp,
+                    constraint "referencing_bad_table_partitioned-fk" foreign key (rbt_id, rbt_value)
+                        references {schemaName}.dict (ref_type, ref_value)
+                ) partition by range (created_at);""",
+            """
+                create table if not exists {schemaName}.referencing_bad_table_default
+                    partition of {schemaName}.referencing_bad_table_partitioned default;""",
+            "insert into {schemaName}.referencing_bad_table_partitioned (rbt_id, rbt_value) values (20, '20');",
+            "insert into {schemaName}.referencing_bad_table_partitioned (rbt_id, rbt_value) values (30, null);"
+        );
+    }
+}

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/AddIntersectedForeignKeysToPartitionedTableStatement.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/AddIntersectedForeignKeysToPartitionedTableStatement.java
@@ -17,8 +17,6 @@ public class AddIntersectedForeignKeysToPartitionedTableStatement extends Abstra
     @Override
     protected List<String> getSqlToExecute() {
         return List.of(
-            "alter table if exists {schemaName}.dict add column ref_value varchar(64);",
-            "create unique index if not exists idx_dict_ref_type_ref_value on {schemaName}.dict (ref_type, ref_value);",
             """
                 alter table if exists {schemaName}.t1
                     add constraint t1_ref_type_ref_value_fk

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/CreateDictTableStatement.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/CreateDictTableStatement.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.core.fixtures.support.statements;
+
+import java.util.List;
+
+public class CreateDictTableStatement extends AbstractDbStatement {
+
+    @Override
+    protected List<String> getSqlToExecute() {
+        return List.of(
+            """
+                create table if not exists {schemaName}.dict(
+                    ref_type int not null primary key,
+                    ref_value varchar(64),
+                    description text
+                );""",
+            "create unique index if not exists idx_dict_ref_type_ref_value on {schemaName}.dict (ref_type, ref_value);",
+            "comment on table {schemaName}.dict is 'Dictionary table for testing composite foreign keys';",
+            "comment on column {schemaName}.dict.ref_type is 'Id of dictionary record';",
+            "comment on column {schemaName}.dict.ref_value is 'Value of dictionary record';",
+            "comment on column {schemaName}.dict.description is 'Description of dictionary record';",
+            "insert into {schemaName}.dict (ref_type, ref_value, description) values (10, '10', 'First value');",
+            "insert into {schemaName}.dict (ref_type, ref_value, description) values (20, '20', 'Second value');"
+        );
+    }
+}

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/CreatePartitionedTableWithSerialAndForeignKeysStatement.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/CreatePartitionedTableWithSerialAndForeignKeysStatement.java
@@ -18,11 +18,6 @@ public class CreatePartitionedTableWithSerialAndForeignKeysStatement extends Abs
     protected List<String> getSqlToExecute() {
         return List.of(
             """
-                create table if not exists {schemaName}.dict(
-                    ref_type int not null primary key,
-                    description text
-                );""",
-            """
                 create table if not exists {schemaName}.t1(
                     ref_value varchar(64) not null,
                     ref_type bigserial not null references {schemaName}.dict(ref_type),

--- a/pg-index-health-generator/build.gradle.kts
+++ b/pg-index-health-generator/build.gradle.kts
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
 plugins {
     id("pg-index-health.java-library")
     id("pg-index-health.pitest")

--- a/pg-index-health-jdbc-connection/build.gradle.kts
+++ b/pg-index-health-jdbc-connection/build.gradle.kts
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
 plugins {
     id("pg-index-health.java-library")
     id("pg-index-health.pitest")

--- a/pg-index-health-logger/build.gradle.kts
+++ b/pg-index-health-logger/build.gradle.kts
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
 plugins {
     id("pg-index-health.java-library")
     id("pg-index-health.mandatory-javadoc")

--- a/pg-index-health-logger/src/test/java/io/github/mfvanek/pg/health/logger/StandardHealthLoggerTest.java
+++ b/pg-index-health-logger/src/test/java/io/github/mfvanek/pg/health/logger/StandardHealthLoggerTest.java
@@ -131,7 +131,8 @@ class StandardHealthLoggerTest extends StatisticsAwareTestBase {
                         "tables_where_primary_key_columns_not_first:3",
                         "tables_where_all_columns_nullable_except_pk:5",
                         "columns_with_char_type:4",
-                        "tables_with_inheritance:0"
+                        "tables_with_inheritance:0",
+                        "foreign_keys_with_null_values:1"
                     );
             }
         );

--- a/pg-index-health-model/build.gradle.kts
+++ b/pg-index-health-model/build.gradle.kts
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
 plugins {
     id("pg-index-health.java-library")
     id("pg-index-health.pitest")

--- a/pg-index-health-testing/build.gradle.kts
+++ b/pg-index-health-testing/build.gradle.kts
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
 plugins {
     id("pg-index-health.java-library")
     //id("pg-index-health.mandatory-javadoc") temporarily disabled due to JPMS support

--- a/pg-index-health/build.gradle.kts
+++ b/pg-index-health/build.gradle.kts
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
 plugins {
     id("pg-index-health.java-library")
     id("pg-index-health.mandatory-javadoc")

--- a/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/ForeignKeysWithNullValuesCheckOnCluster.java
+++ b/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/ForeignKeysWithNullValuesCheckOnCluster.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.health.checks.cluster;
+
+import io.github.mfvanek.pg.connection.HighAvailabilityPgConnection;
+import io.github.mfvanek.pg.core.checks.host.ForeignKeysWithNullValuesCheckOnHost;
+import io.github.mfvanek.pg.model.constraint.ForeignKey;
+
+/**
+ * Check for composite (multi-column) foreign keys with nullable columns
+ * that are not defined with MATCH FULL on all hosts in the cluster.
+ *
+ * @author Ivan Vakhrushev
+ * @since 0.41.0
+ */
+public class ForeignKeysWithNullValuesCheckOnCluster extends AbstractCheckOnCluster<ForeignKey> {
+
+    /**
+     * Constructs a new instance of {@code ForeignKeysWithNullValuesCheckOnCluster}.
+     *
+     * @param haPgConnection the high-availability connection to the PostgreSQL cluster; must not be null
+     */
+    public ForeignKeysWithNullValuesCheckOnCluster(final HighAvailabilityPgConnection haPgConnection) {
+        super(haPgConnection, ForeignKeysWithNullValuesCheckOnHost::new);
+    }
+}

--- a/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/StandardChecksOnCluster.java
+++ b/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/StandardChecksOnCluster.java
@@ -80,7 +80,8 @@ public final class StandardChecksOnCluster implements Function<HighAvailabilityP
             new TablesWherePrimaryKeyColumnsNotFirstCheckOnCluster(haPgConnection),
             new TablesWhereAllColumnsNullableExceptPrimaryKeyCheckOnCluster(haPgConnection),
             new ColumnsWithCharTypeCheckOnCluster(haPgConnection),
-            new TablesWithInheritanceCheckOnCluster(haPgConnection)
+            new TablesWithInheritanceCheckOnCluster(haPgConnection),
+            new ForeignKeysWithNullValuesCheckOnCluster(haPgConnection)
         );
     }
 }

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ForeignKeysWithNullValuesCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/ForeignKeysWithNullValuesCheckOnClusterTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.health.checks.cluster;
+
+import io.github.mfvanek.pg.core.checks.common.Diagnostic;
+import io.github.mfvanek.pg.core.fixtures.support.DatabaseAwareTestBase;
+import io.github.mfvanek.pg.core.fixtures.support.DatabasePopulator;
+import io.github.mfvanek.pg.health.checks.common.DatabaseCheckOnCluster;
+import io.github.mfvanek.pg.model.column.Column;
+import io.github.mfvanek.pg.model.constraint.ForeignKey;
+import io.github.mfvanek.pg.model.context.PgContext;
+import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.assertThat;
+
+class ForeignKeysWithNullValuesCheckOnClusterTest extends DatabaseAwareTestBase {
+
+    private final DatabaseCheckOnCluster<@NonNull ForeignKey> check = new ForeignKeysWithNullValuesCheckOnCluster(getHaPgConnection());
+
+    @Test
+    void shouldSatisfyContract() {
+        assertThat(check)
+            .hasType(ForeignKey.class)
+            .hasDiagnostic(Diagnostic.FOREIGN_KEYS_WITH_NULL_VALUES)
+            .isStatic();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
+    void onDatabaseWithThem(final String schemaName) {
+        executeTestOnDatabase(schemaName, dbp -> dbp.withReferences().withForeignKeyOnNullableColumn().withCompositeForeignKey(), ctx -> {
+            final String tableName = "referencing_bad_table";
+            assertThat(check)
+                .executing(ctx)
+                .hasSize(2)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(
+                    ForeignKey.of(ctx, "bad_clients", "c_bad_clients_fk_email_phone", List.of(
+                        Column.ofNullable(ctx, "bad_clients", "email"),
+                        Column.ofNullable(ctx, "bad_clients", "phone"))),
+                    ForeignKey.of(ctx, tableName, "\"referencing-bad-table-fk\"", List.of(
+                        Column.ofNotNull(ctx, tableName, "rbt_id"),
+                        Column.ofNullable(ctx, tableName, "rbt_value")
+                    ))
+                );
+
+            assertThat(check)
+                .executing(ctx, SkipTablesByNamePredicate.of(ctx, List.of(tableName, "bad_clients")))
+                .isEmpty();
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
+    void shouldWorkWithPartitionedTables(final String schemaName) {
+        executeTestOnDatabase(schemaName, DatabasePopulator::withCompositeForeignKeyInPartitionedTable, ctx -> {
+            final String tableName = "referencing_bad_table_partitioned";
+            assertThat(check)
+                .executing(ctx)
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(
+                    ForeignKey.of(ctx, tableName, "\"referencing_bad_table_partitioned-fk\"", List.of(
+                        Column.ofNotNull(ctx, tableName, "rbt_id"),
+                        Column.ofNullable(ctx, tableName, "rbt_value")
+                    ))
+                );
+        });
+    }
+}

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IntersectedIndexesCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IntersectedIndexesCheckOnClusterTest.java
@@ -107,9 +107,12 @@ class IntersectedIndexesCheckOnClusterTest extends DatabaseAwareTestBase {
         executeTestOnDatabase(schemaName, dbp -> dbp.withSerialAndForeignKeysInPartitionedTable().withDuplicatedAndIntersectedIndexesInPartitionedTable(), ctx ->
             assertThat(check)
                 .executing(ctx)
-                .hasSize(2)
+                .hasSize(3)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(
+                    DuplicatedIndexes.of(
+                        Index.of(ctx, "dict", "dict_pkey", 16_384L),
+                        Index.of(ctx, "dict", "idx_dict_ref_type_ref_value", 16_384L)),
                     DuplicatedIndexes.of(
                         Index.of(ctx, "t1", "idx_t1_deleted_duplicate"),
                         Index.of(ctx, "t1", "idx_t1_deleted_entity_id")),

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
 rootProject.name = "pg-index-health-build"
 
 include("pg-index-health-model")

--- a/spring-boot-integration/pg-index-health-test-starter/src/main/java/io/github/mfvanek/pg/spring/DatabaseStructureChecksAutoConfiguration.java
+++ b/spring-boot-integration/pg-index-health-test-starter/src/main/java/io/github/mfvanek/pg/spring/DatabaseStructureChecksAutoConfiguration.java
@@ -23,6 +23,7 @@ import io.github.mfvanek.pg.core.checks.host.ColumnsWithoutDescriptionCheckOnHos
 import io.github.mfvanek.pg.core.checks.host.DuplicatedForeignKeysCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.DuplicatedIndexesCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysNotCoveredWithIndexCheckOnHost;
+import io.github.mfvanek.pg.core.checks.host.ForeignKeysWithNullValuesCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysWithUnmatchedColumnTypeCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.FunctionsWithoutDescriptionCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.IndexesWithBloatCheckOnHost;
@@ -340,6 +341,13 @@ public class DatabaseStructureChecksAutoConfiguration {
     @ConditionalOnMissingBean
     public TablesWithInheritanceCheckOnHost tablesWithInheritanceCheckOnHost(final PgConnection pgConnection) {
         return new TablesWithInheritanceCheckOnHost(pgConnection);
+    }
+
+    @Bean
+    @ConditionalOnClass(ForeignKeysWithNullValuesCheckOnHost.class)
+    @ConditionalOnMissingBean
+    public ForeignKeysWithNullValuesCheckOnHost foreignKeysWithNullValuesCheckOnHost(final PgConnection pgConnection) {
+        return new ForeignKeysWithNullValuesCheckOnHost(pgConnection);
     }
 
     @Bean

--- a/spring-boot-integration/pg-index-health-test-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-integration/pg-index-health-test-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,12 @@
+#
+# Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+# https://github.com/mfvanek/pg-index-health
+#
+# This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+# that detects common anti-patterns and promotes best practices.
+#
+# Licensed under the Apache License 2.0
+#
+
 io.github.mfvanek.pg.spring.DatabaseStructureHealthAutoConfiguration
 io.github.mfvanek.pg.spring.DatabaseStructureChecksAutoConfiguration

--- a/spring-boot-integration/pg-index-health-test-starter/src/test/java/io/github/mfvanek/pg/spring/AutoConfigurationTestBase.java
+++ b/spring-boot-integration/pg-index-health-test-starter/src/test/java/io/github/mfvanek/pg/spring/AutoConfigurationTestBase.java
@@ -24,6 +24,7 @@ import io.github.mfvanek.pg.core.checks.host.ColumnsWithoutDescriptionCheckOnHos
 import io.github.mfvanek.pg.core.checks.host.DuplicatedForeignKeysCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.DuplicatedIndexesCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysNotCoveredWithIndexCheckOnHost;
+import io.github.mfvanek.pg.core.checks.host.ForeignKeysWithNullValuesCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysWithUnmatchedColumnTypeCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.FunctionsWithoutDescriptionCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.IndexesWithBloatCheckOnHost;
@@ -160,7 +161,8 @@ abstract class AutoConfigurationTestBase {
             TablesWherePrimaryKeyColumnsNotFirstCheckOnHost.class,
             TablesWhereAllColumnsNullableExceptPrimaryKeyCheckOnHost.class,
             ColumnsWithCharTypeCheckOnHost.class,
-            TablesWithInheritanceCheckOnHost.class
+            TablesWithInheritanceCheckOnHost.class,
+            ForeignKeysWithNullValuesCheckOnHost.class
         );
     }
 }


### PR DESCRIPTION
Closes https://github.com/mfvanek/pg-index-health/issues/389

### Common steps

- [x] Read [CONTRIBUTING.md](https://github.com/mfvanek/pg-index-health/blob/master/CONTRIBUTING.md)
- [x] Linked to an issue
- [x] Added a description to PR

### For a database check

- [x] I have updated the [list of checks](https://github.com/mfvanek/pg-index-health/blob/master/doc/available_checks.md)
- [x] I have added the same tests for a check on host and a check on cluster
- [x] The check results are validated with `containsExactly()` and `usingRecursiveFieldByFieldElementComparator()`

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
