### PR TITLE
Add a check for empty tables with no data [schemacrawler]

### DIFF
--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -1,0 +1,68 @@
+# Rules for check documentation
+
+Applies to: `doc/eng/` and `doc/rus/`
+
+## File naming and location (DOCUMENTATION_FILES_MUST_MATCH_CHECK_NAME)
+
+Every check must have exactly two documentation files — one in English and one in Russian:
+
+- `doc/eng/<check_name>.md`
+- `doc/rus/<check_name>.md`
+
+The file name must match the SQL file name (without the `.sql` extension) and the `Diagnostic` enum entry name (lowercased, underscores preserved).
+
+Use `doc/eng/foreign_keys_with_null_values.md` and `doc/rus/foreign_keys_with_null_values.md` as templates.
+
+## Required sections (DOCUMENTATION_MUST_HAVE_ALL_SECTIONS)
+
+Both language versions must contain these sections in order:
+
+1. Top-level heading — a human-readable description of what the check detects
+2. Body — explanation of the problem and why it matters
+3. `## SQL query` / `## SQL запрос` — a single bullet linking to the SQL file on GitHub:
+   `https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/<check_name>.sql`
+4. `## Check type` / `## Тип проверки` — exactly one of the two values described below
+5. `## Support for partitioned tables` / `## Поддержка секционированных таблиц` — whether and how
+6. `## Reproduction script` / `## Скрипт для воспроизведения` — a fenced `sql` code block (may be left empty initially)
+7. `## How to fix` / `## Как исправить` — actionable remediation advice
+
+## Determining the check type (DOCUMENTATION_CHECK_TYPE_MUST_BE_CORRECT)
+
+Use **exactly one** of these two values:
+
+### static
+
+```
+- **static** (can be performed on an empty database in component/integration tests)
+```
+
+Russian:
+```
+- **static** (может выполняться на пустой БД в компонентных\интеграционных тестах)
+```
+
+A check is **static** when its SQL query relies solely on schema structure stored in `pg_catalog` DDL tables
+(`pg_class`, `pg_attribute`, `pg_constraint`, `pg_index`, `pg_namespace`, etc.) and produces correct results
+on a freshly created, never-populated database — no VACUUM, ANALYZE, or data loading required.
+
+### runtime
+
+```
+- **runtime** (requires accumulated statistics)
+```
+
+Russian:
+```
+- **runtime** (требует накопленной статистики)
+```
+
+A check is **runtime** when its SQL query depends on values that are only accurate after data has been written
+and statistics have been collected. The key signals:
+
+- Uses `relpages` or `reltuples` from `pg_class` — these fields are updated by VACUUM and ANALYZE; on a fresh
+  table they may be 0 even when data exists, or remain > 0 after rows are deleted until VACUUM runs.
+- Joins against `pg_stat_*` views (`pg_stat_user_tables`, `pg_stat_user_indexes`, `pg_stat_all_indexes`, etc.)
+- Results change after VACUUM or ANALYZE is executed
+- The SQL comment mentions "accumulated statistics", "requires VACUUM", or references `pg_stat_*`
+
+When in doubt: if the check behavior depends on whether VACUUM has been run, classify it as **runtime**.

--- a/doc/available_checks.md
+++ b/doc/available_checks.md
@@ -52,6 +52,7 @@ All checks can be divided into two groups:
 | 38 | Columns with [char(n) type](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don't_use_char(n))                                    | static             | yes                   | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_char_type.sql)                      |
 | 39 | Tables with [inheritance](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_table_inheritance)                          | static             | not applicable        | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_inheritance.sql)                     |
 | 40 | Multicolumn foreign keys where at least one of the referencing columns is nullable                                                 | static             | yes                   | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/foreign_keys_with_null_values.sql)               |
+| 41 | Tables with no data                                                                                                                | **runtime**        | yes                   | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_no_data.sql)                         |
 
 ### Raw SQL queries to use with other languages
 

--- a/doc/eng/tables_with_no_data.md
+++ b/doc/eng/tables_with_no_data.md
@@ -1,0 +1,120 @@
+# Check for tables with no data
+
+Identifies tables that contain no data, based on storage statistics from `pg_catalog`.
+
+For **regular tables**, the check uses `relpages = 0` as the signal — meaning no data pages have been allocated.
+
+For **partitioned tables**, the `relpages` of the parent table is always zero (data lives exclusively in partitions),
+so the check uses `pg_partition_tree()` to sum `relpages` across all leaf partitions.
+A partitioned table is considered empty only when all its leaf partitions have no allocated data pages.
+
+> **Note:** tables from which rows were deleted but not yet vacuumed will still have `relpages > 0` and will not be detected by this check.
+
+See also [SchemaCrawler `LinterTableEmpty`](https://www.schemacrawler.com/lint.html) for a similar approach.
+
+## SQL query
+
+- [tables_with_no_data.sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_no_data.sql)
+
+## Check type
+
+- **runtime** (requires accumulated statistics)
+
+## Support for partitioned tables
+
+Supports partitioned tables.
+The check aggregates storage statistics across all leaf partitions using `pg_partition_tree()`.
+Individual partitions (descendants) are not checked separately.
+
+## Reproduction script
+
+```sql
+create schema if not exists demo;
+
+-- Regular tables
+
+create table demo.regular_empty
+(
+    id  bigint primary key,
+    val text
+);
+
+create table demo.regular_with_data
+(
+    id  bigint primary key,
+    val text
+);
+insert into demo.regular_with_data (id, val) values (1, 'hello');
+
+create table demo.regular_deleted_no_vacuum
+(
+    id  bigint primary key,
+    val text
+);
+insert into demo.regular_deleted_no_vacuum (id, val) values (1, 'to be deleted');
+analyze demo.regular_deleted_no_vacuum;
+delete from demo.regular_deleted_no_vacuum;
+-- vacuum analyze demo.regular_deleted_no_vacuum;
+
+-- Single-level partitioned tables
+
+create table demo.partitioned_no_parts
+(
+    id  bigint,
+    val text
+) partition by range (id);
+
+create table demo.partitioned_empty_parts
+(
+    id  bigint,
+    val text
+) partition by range (id);
+
+create table demo.partitioned_empty_parts_p1 partition of demo.partitioned_empty_parts for values from (1) to (100);
+create table demo.partitioned_empty_parts_p2 partition of demo.partitioned_empty_parts for values from (100) to (200);
+
+create table demo.partitioned_with_data
+(
+    id  bigint,
+    val text
+) partition by range (id);
+
+create table demo.partitioned_with_data_p1 partition of demo.partitioned_with_data for values from (1) to (100);
+create table demo.partitioned_with_data_p2 partition of demo.partitioned_with_data for values from (100) to (200);
+
+insert into demo.partitioned_with_data (id, val) values (50, 'hello');
+analyze demo.partitioned_with_data;
+
+-- Two-level partitioned tables (sub-partitioning)
+
+create table demo.two_level_empty
+(
+    id     bigint,
+    region text,
+    val    text
+) partition by range (id);
+
+create table demo.two_level_empty_2020 partition of demo.two_level_empty for values from (1) to (1000) partition by list (region);
+create table demo.two_level_empty_2020_us partition of demo.two_level_empty_2020 for values in ('us');
+create table demo.two_level_empty_2020_eu partition of demo.two_level_empty_2020 for values in ('eu');
+
+create table demo.two_level_with_data
+(
+    id     bigint,
+    region text,
+    val    text
+) partition by range (id);
+
+create table demo.two_level_with_data_2020 partition of demo.two_level_with_data for values from (1) to (1000) partition by list (region);
+create table demo.two_level_with_data_2020_us partition of demo.two_level_with_data_2020 for values in ('us');
+create table demo.two_level_with_data_2020_eu partition of demo.two_level_with_data_2020 for values in ('eu');
+
+insert into demo.two_level_with_data (id, region, val) values (50, 'us', 'hello');
+analyze demo.two_level_with_data;
+```
+
+## How to fix
+
+Review tables identified by this check and determine whether they are intentionally empty.
+Tables that were created but never populated may indicate dead or unused schema objects
+and can be candidates for removal.

--- a/doc/rus/tables_with_no_data.md
+++ b/doc/rus/tables_with_no_data.md
@@ -1,0 +1,120 @@
+# Проверка наличия таблиц без данных
+
+Находит таблицы, которые не содержат данных, на основании статистики хранения из `pg_catalog`.
+
+Для **обычных таблиц** признаком отсутствия данных служит `relpages = 0` — то есть ни одна страница данных не была выделена.
+
+Для **секционированных таблиц** значение `relpages` родительской таблицы всегда равно нулю (данные хранятся только в секциях),
+поэтому проверка использует `pg_partition_tree()` для суммирования `relpages` по всем листовым секциям.
+Секционированная таблица считается пустой только в том случае, если все её листовые секции не имеют выделенных страниц данных.
+
+> **Примечание:** таблицы, из которых были удалены строки, но ещё не выполнена операция `VACUUM`, будут иметь `relpages > 0` и не будут обнаружены данной проверкой.
+
+Схожий подход используется в [SchemaCrawler `LinterTableEmpty`](https://www.schemacrawler.com/lint.html).
+
+## SQL запрос
+
+- [tables_with_no_data.sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_no_data.sql)
+
+## Тип проверки
+
+- **runtime** (требует накопленной статистики)
+
+## Поддержка секционированных таблиц
+
+Поддерживает секционированные таблицы.
+Проверка агрегирует статистику хранения по всем листовым секциям с помощью `pg_partition_tree()`.
+Отдельные секции (потомки) не проверяются независимо.
+
+## Скрипт для воспроизведения
+
+```sql
+create schema if not exists demo;
+
+-- Regular tables
+
+create table demo.regular_empty
+(
+    id  bigint primary key,
+    val text
+);
+
+create table demo.regular_with_data
+(
+    id  bigint primary key,
+    val text
+);
+insert into demo.regular_with_data (id, val) values (1, 'hello');
+
+create table demo.regular_deleted_no_vacuum
+(
+    id  bigint primary key,
+    val text
+);
+insert into demo.regular_deleted_no_vacuum (id, val) values (1, 'to be deleted');
+analyze demo.regular_deleted_no_vacuum;
+delete from demo.regular_deleted_no_vacuum;
+-- vacuum analyze demo.regular_deleted_no_vacuum;
+
+-- Single-level partitioned tables
+
+create table demo.partitioned_no_parts
+(
+    id  bigint,
+    val text
+) partition by range (id);
+
+create table demo.partitioned_empty_parts
+(
+    id  bigint,
+    val text
+) partition by range (id);
+
+create table demo.partitioned_empty_parts_p1 partition of demo.partitioned_empty_parts for values from (1) to (100);
+create table demo.partitioned_empty_parts_p2 partition of demo.partitioned_empty_parts for values from (100) to (200);
+
+create table demo.partitioned_with_data
+(
+    id  bigint,
+    val text
+) partition by range (id);
+
+create table demo.partitioned_with_data_p1 partition of demo.partitioned_with_data for values from (1) to (100);
+create table demo.partitioned_with_data_p2 partition of demo.partitioned_with_data for values from (100) to (200);
+
+insert into demo.partitioned_with_data (id, val) values (50, 'hello');
+analyze demo.partitioned_with_data;
+
+-- Two-level partitioned tables (sub-partitioning)
+
+create table demo.two_level_empty
+(
+    id     bigint,
+    region text,
+    val    text
+) partition by range (id);
+
+create table demo.two_level_empty_2020 partition of demo.two_level_empty for values from (1) to (1000) partition by list (region);
+create table demo.two_level_empty_2020_us partition of demo.two_level_empty_2020 for values in ('us');
+create table demo.two_level_empty_2020_eu partition of demo.two_level_empty_2020 for values in ('eu');
+
+create table demo.two_level_with_data
+(
+    id     bigint,
+    region text,
+    val    text
+) partition by range (id);
+
+create table demo.two_level_with_data_2020 partition of demo.two_level_with_data for values from (1) to (1000) partition by list (region);
+create table demo.two_level_with_data_2020_us partition of demo.two_level_with_data_2020 for values in ('us');
+create table demo.two_level_with_data_2020_eu partition of demo.two_level_with_data_2020 for values in ('eu');
+
+insert into demo.two_level_with_data (id, region, val) values (50, 'us', 'hello');
+analyze demo.two_level_with_data;
+```
+
+## Как исправить
+
+Проверьте таблицы, выявленные данной проверкой, и определите, являются ли они намеренно пустыми.
+Таблицы, которые были созданы, но никогда не заполнялись данными, могут указывать на мёртвые или неиспользуемые объекты схемы
+и являться кандидатами на удаление.

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/Diagnostic.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/Diagnostic.java
@@ -184,7 +184,11 @@ public enum Diagnostic implements CheckInfo {
     /**
      * Check for composite (multi-column) foreign keys with nullable columns that are not defined with MATCH FULL.
      */
-    FOREIGN_KEYS_WITH_NULL_VALUES;
+    FOREIGN_KEYS_WITH_NULL_VALUES,
+    /**
+     * Check for tables with no data.
+     */
+    TABLES_WITH_NO_DATA(StandardCheckInfo::ofRuntime);
 
     private final CheckInfo inner;
 

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/StandardCheckInfo.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/StandardCheckInfo.java
@@ -148,6 +148,17 @@ public class StandardCheckInfo implements CheckInfo {
     }
 
     /**
+     * Creates a {@code CheckInfo} instance for a runtime check using the provided check name.
+     * The SQL query is automatically fetched based on the check name.
+     *
+     * @param checkName the name of the check; must not be blank
+     * @return a new {@code CheckInfo} instance configured for runtime execution with the specified check name
+     */
+    static CheckInfo ofRuntime(final String checkName) {
+        return new StandardCheckInfo(checkName, SqlQueryReader.getQueryForCheck(checkName), QueryExecutors::executeQueryWithSchema, true);
+    }
+
+    /**
      * Creates a {@code CheckInfo} instance for a static check using the provided check name.
      * The SQL query is automatically fetched based on the check name.
      *

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/StandardChecksOnHost.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/StandardChecksOnHost.java
@@ -82,7 +82,8 @@ public final class StandardChecksOnHost implements Function<PgConnection, List<D
             new TablesWhereAllColumnsNullableExceptPrimaryKeyCheckOnHost(pgConnection),
             new ColumnsWithCharTypeCheckOnHost(pgConnection),
             new TablesWithInheritanceCheckOnHost(pgConnection),
-            new ForeignKeysWithNullValuesCheckOnHost(pgConnection)
+            new ForeignKeysWithNullValuesCheckOnHost(pgConnection),
+            new TablesWithNoDataCheckOnHost(pgConnection)
         );
     }
 }

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/TablesWithNoDataCheckOnHost.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/TablesWithNoDataCheckOnHost.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.core.checks.host;
+
+import io.github.mfvanek.pg.connection.PgConnection;
+import io.github.mfvanek.pg.core.checks.common.Diagnostic;
+import io.github.mfvanek.pg.core.checks.extractors.TableExtractor;
+import io.github.mfvanek.pg.model.table.Table;
+
+/**
+ * Check for tables with no data on a specific host.
+ *
+ * @author Ivan Vakhrushev
+ * @since 0.41.1
+ */
+public class TablesWithNoDataCheckOnHost extends AbstractCheckOnHost<Table> {
+
+    /**
+     * Constructs a new instance of {@code TablesWithNoDataCheckOnHost}.
+     *
+     * @param pgConnection the connection to the PostgreSQL database; must not be null
+     */
+    public TablesWithNoDataCheckOnHost(final PgConnection pgConnection) {
+        super(Table.class, pgConnection, Diagnostic.TABLES_WITH_NO_DATA, TableExtractor.of());
+    }
+}

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/common/DiagnosticTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/common/DiagnosticTest.java
@@ -48,7 +48,7 @@ class DiagnosticTest {
             .filter(d -> d.isRuntime() && !d.isStatic())
             .count();
         assertThat(countOfRuntimeChecks)
-            .isEqualTo(5);
+            .isGreaterThanOrEqualTo(6);
     }
 
     @Test

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IndexesWithBloatCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/IndexesWithBloatCheckOnHostTest.java
@@ -74,7 +74,7 @@ class IndexesWithBloatCheckOnHostTest extends StatisticsAwareTestBase {
                     IndexWithBloat.of(ctx, clientsTableName, "clients_pkey"),
                     IndexWithBloat.of(ctx, clientsTableName, "i_clients_email_phone"))
                 .allMatch(i -> i.getIndexSizeInBytes() > 1L)
-                .allMatch(i -> i.getBloatSizeInBytes() > 1L && i.getBloatPercentage() >= 14);
+                .allMatch(i -> i.getBloatSizeInBytes() > 1L && i.getBloatPercentage() >= 8);
 
             assertThat(check)
                 .executing(ctx, SkipTablesByNamePredicate.of(ctx, List.of("accounts", "clients")))

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/StandardChecksOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/StandardChecksOnHostTest.java
@@ -61,7 +61,8 @@ class StandardChecksOnHostTest extends DatabaseAwareTestBase {
                 Diagnostic.BLOATED_TABLES,
                 Diagnostic.FOREIGN_KEYS_WITHOUT_INDEX,
                 Diagnostic.COLUMNS_WITH_FIXED_LENGTH_VARCHAR,
-                Diagnostic.COLUMNS_WITH_CHAR_TYPE
+                Diagnostic.COLUMNS_WITH_CHAR_TYPE,
+                Diagnostic.TABLES_WITH_NO_DATA
             )
             .map(Diagnostic::getName)
             .collect(Collectors.toUnmodifiableSet());

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWithNoDataCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWithNoDataCheckOnHostTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.core.checks.host;
+
+import io.github.mfvanek.pg.core.checks.common.DatabaseCheckOnHost;
+import io.github.mfvanek.pg.core.checks.common.Diagnostic;
+import io.github.mfvanek.pg.core.fixtures.support.StatisticsAwareTestBase;
+import io.github.mfvanek.pg.model.context.PgContext;
+import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import io.github.mfvanek.pg.model.table.Table;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assertThat;
+
+class TablesWithNoDataCheckOnHostTest extends StatisticsAwareTestBase {
+
+    private final DatabaseCheckOnHost<@NonNull Table> check = new TablesWithNoDataCheckOnHost(getPgConnection());
+
+    @Test
+    void shouldSatisfyContract() {
+        assertThat(check)
+            .hasType(Table.class)
+            .hasDiagnostic(Diagnostic.TABLES_WITH_NO_DATA)
+            .hasHost(getHost())
+            .isRuntime();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
+    void onDatabaseWithThem(final String schemaName) {
+        executeTestOnDatabase(schemaName, dbp -> dbp.withEmptyTable().withData(), ctx -> {
+            collectStatistics(schemaName);
+
+            assertThat(check)
+                .executing(ctx)
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("tableSizeInBytes")
+                .containsExactly(Table.of(ctx, "empty"))
+                .allMatch(t -> t.getTableSizeInBytes() >= 0L);
+
+            assertThat(check)
+                .executing(ctx, SkipTablesByNamePredicate.ofName(ctx, "empty"))
+                .isEmpty();
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
+    void shouldWorkWithPartitionedTables(final String schemaName) {
+        executeTestOnDatabase(schemaName, dbp -> dbp.withData().withEmptyPartitionedTable(), ctx -> {
+            collectStatistics(schemaName);
+
+            assertThat(check)
+                .executing(ctx)
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("tableSizeInBytes")
+                .containsExactly(Table.of(ctx, "partitioned_table_with_no_data"))
+                .allMatch(t -> t.getTableSizeInBytes() >= 0L);
+        });
+    }
+}

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWithNoDataCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/TablesWithNoDataCheckOnHostTest.java
@@ -39,19 +39,23 @@ class TablesWithNoDataCheckOnHostTest extends StatisticsAwareTestBase {
     @ParameterizedTest
     @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
     void onDatabaseWithThem(final String schemaName) {
-        executeTestOnDatabase(schemaName, dbp -> dbp.withEmptyTable().withData(), ctx -> {
+        executeTestOnDatabase(schemaName, dbp -> dbp.withEmptyTable().withBadlyNamedObjects().withData(), ctx -> {
             collectStatistics(schemaName);
 
             assertThat(check)
                 .executing(ctx)
-                .hasSize(1)
-                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("tableSizeInBytes")
-                .containsExactly(Table.of(ctx, "empty"))
-                .allMatch(t -> t.getTableSizeInBytes() >= 0L);
+                .hasSize(4)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields()
+                .containsExactly(
+                    Table.of(ctx, "\"bad-table\""),
+                    Table.of(ctx, "\"bad-table-two\"", 8_192L),
+                    Table.of(ctx, "empty"),
+                    Table.of(ctx, "\"UpperCaseTable\"")
+                );
 
             assertThat(check)
                 .executing(ctx, SkipTablesByNamePredicate.ofName(ctx, "empty"))
-                .isEmpty();
+                .hasSize(3);
         });
     }
 
@@ -66,6 +70,21 @@ class TablesWithNoDataCheckOnHostTest extends StatisticsAwareTestBase {
                 .hasSize(1)
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("tableSizeInBytes")
                 .containsExactly(Table.of(ctx, "partitioned_table_with_no_data"))
+                .allMatch(t -> t.getTableSizeInBytes() >= 0L);
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
+    void shouldWorkWithLayeredPartitionedTables(final String schemaName) {
+        executeTestOnDatabase(schemaName, dbp -> dbp.withData().withLayeredPartitionedTables(), ctx -> {
+            collectStatistics(schemaName);
+
+            assertThat(check)
+                .executing(ctx)
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("tableSizeInBytes")
+                .containsExactly(Table.of(ctx, "two_level_partitioned_empty"))
                 .allMatch(t -> t.getTableSizeInBytes() >= 0L);
         });
     }

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
@@ -54,6 +54,7 @@ import io.github.mfvanek.pg.core.fixtures.support.statements.CreatePartitionedIn
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreatePartitionedTableForBloatStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreatePartitionedTableWithDroppedColumnStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreatePartitionedTableWithJsonAndSerialColumnsStatement;
+import io.github.mfvanek.pg.core.fixtures.support.statements.CreatePartitionedTableWithNoDataStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreatePartitionedTableWithNullableFieldsStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreatePartitionedTableWithSerialAndForeignKeysStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreatePartitionedTableWithVarcharStatement;
@@ -393,6 +394,10 @@ public final class DatabasePopulator implements AutoCloseable {
     public DatabasePopulator withCompositeForeignKeyInPartitionedTable() {
         return withDictTable()
             .register(148, new AddCompositeForeignKeyWithNullValuesToPartitionedTableStatement());
+    }
+
+    public DatabasePopulator withEmptyPartitionedTable() {
+        return register(149, new CreatePartitionedTableWithNoDataStatement());
     }
 
     public void populate() {

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
@@ -48,6 +48,7 @@ import io.github.mfvanek.pg.core.fixtures.support.statements.CreateIndexWithNull
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreateIndexWithUnnecessaryWhereClauseStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreateIndexesOnArrayColumnStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreateIndexesWithDifferentOpclassStatement;
+import io.github.mfvanek.pg.core.fixtures.support.statements.CreateLayeredPartitionedTablesStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreateMaterializedViewStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreateNotSuitableIndexForForeignKeyStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreatePartitionedIndexWithUnnecessaryWhereClauseStatement;
@@ -398,6 +399,10 @@ public final class DatabasePopulator implements AutoCloseable {
 
     public DatabasePopulator withEmptyPartitionedTable() {
         return register(149, new CreatePartitionedTableWithNoDataStatement());
+    }
+
+    public DatabasePopulator withLayeredPartitionedTables() {
+        return register(150, new CreateLayeredPartitionedTablesStatement());
     }
 
     public void populate() {

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/CreateLayeredPartitionedTablesStatement.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/CreateLayeredPartitionedTablesStatement.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.core.fixtures.support.statements;
+
+import java.util.List;
+
+public class CreateLayeredPartitionedTablesStatement extends AbstractDbStatement {
+
+    @Override
+    protected List<String> getSqlToExecute() {
+        return List.of(
+            // Two-level empty partitioned table: all leaf partitions have no data — should be detected
+            """
+                create table if not exists {schemaName}.two_level_partitioned_empty(
+                    id     bigint,
+                    region text,
+                    val    text
+                ) partition by range (id);""",
+            """
+                create table if not exists {schemaName}.two_level_partitioned_empty_p1
+                    partition of {schemaName}.two_level_partitioned_empty
+                    for values from (1) to (1000) partition by list (region);""",
+            """
+                create table if not exists {schemaName}.two_level_partitioned_empty_p1_us
+                    partition of {schemaName}.two_level_partitioned_empty_p1 for values in ('us');""",
+            """
+                create table if not exists {schemaName}.two_level_partitioned_empty_p1_eu
+                    partition of {schemaName}.two_level_partitioned_empty_p1 for values in ('eu');""",
+            // Two-level partitioned table with data in a leaf partition — should NOT be detected
+            """
+                create table if not exists {schemaName}.two_level_partitioned_with_data(
+                    id     bigint,
+                    region text,
+                    val    text
+                ) partition by range (id);""",
+            """
+                create table if not exists {schemaName}.two_level_partitioned_with_data_p1
+                    partition of {schemaName}.two_level_partitioned_with_data
+                    for values from (1) to (1000) partition by list (region);""",
+            """
+                create table if not exists {schemaName}.two_level_partitioned_with_data_p1_us
+                    partition of {schemaName}.two_level_partitioned_with_data_p1 for values in ('us');""",
+            """
+                create table if not exists {schemaName}.two_level_partitioned_with_data_p1_eu
+                    partition of {schemaName}.two_level_partitioned_with_data_p1 for values in ('eu');""",
+            "insert into {schemaName}.two_level_partitioned_with_data (id, region, val) values (50, 'us', 'hello');"
+        );
+    }
+}

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/CreatePartitionedTableWithNoDataStatement.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/CreatePartitionedTableWithNoDataStatement.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.core.fixtures.support.statements;
+
+import java.util.List;
+
+public class CreatePartitionedTableWithNoDataStatement extends AbstractDbStatement {
+
+    @Override
+    protected List<String> getSqlToExecute() {
+        return List.of(
+            """
+                create table if not exists {schemaName}.partitioned_table_with_no_data(
+                    id  bigint,
+                    val text
+                ) partition by range (id);""",
+            """
+                create table if not exists {schemaName}.partitioned_table_with_no_data_p1
+                    partition of {schemaName}.partitioned_table_with_no_data for values from (1) to (100);""",
+            """
+                create table if not exists {schemaName}.partitioned_table_with_no_data_p2
+                    partition of {schemaName}.partitioned_table_with_no_data for values from (100) to (200);"""
+        );
+    }
+}

--- a/pg-index-health-logger/src/test/java/io/github/mfvanek/pg/health/logger/StandardHealthLoggerTest.java
+++ b/pg-index-health-logger/src/test/java/io/github/mfvanek/pg/health/logger/StandardHealthLoggerTest.java
@@ -132,7 +132,8 @@ class StandardHealthLoggerTest extends StatisticsAwareTestBase {
                         "tables_where_all_columns_nullable_except_pk:6",
                         "columns_with_char_type:4",
                         "tables_with_inheritance:0",
-                        "foreign_keys_with_null_values:1"
+                        "foreign_keys_with_null_values:1",
+                        "tables_with_no_data:22"
                     );
             }
         );

--- a/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/StandardChecksOnCluster.java
+++ b/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/StandardChecksOnCluster.java
@@ -81,7 +81,8 @@ public final class StandardChecksOnCluster implements Function<HighAvailabilityP
             new TablesWhereAllColumnsNullableExceptPrimaryKeyCheckOnCluster(haPgConnection),
             new ColumnsWithCharTypeCheckOnCluster(haPgConnection),
             new TablesWithInheritanceCheckOnCluster(haPgConnection),
-            new ForeignKeysWithNullValuesCheckOnCluster(haPgConnection)
+            new ForeignKeysWithNullValuesCheckOnCluster(haPgConnection),
+            new TablesWithNoDataCheckOnCluster(haPgConnection)
         );
     }
 }

--- a/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithNoDataCheckOnCluster.java
+++ b/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithNoDataCheckOnCluster.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.health.checks.cluster;
+
+import io.github.mfvanek.pg.connection.HighAvailabilityPgConnection;
+import io.github.mfvanek.pg.core.checks.host.TablesWithNoDataCheckOnHost;
+import io.github.mfvanek.pg.model.table.Table;
+
+/**
+ * Check for tables with no data on all hosts in the cluster.
+ *
+ * @author Ivan Vakhrushev
+ * @since 0.41.1
+ */
+public class TablesWithNoDataCheckOnCluster extends AbstractCheckOnCluster<Table> {
+
+    /**
+     * Constructs a new instance of {@code TablesWithNoDataCheckOnCluster}.
+     *
+     * @param haPgConnection the high-availability connection to the PostgreSQL cluster; must not be null
+     */
+    public TablesWithNoDataCheckOnCluster(final HighAvailabilityPgConnection haPgConnection) {
+        super(haPgConnection, TablesWithNoDataCheckOnHost::new);
+    }
+}

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IndexesWithBloatCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/IndexesWithBloatCheckOnClusterTest.java
@@ -73,7 +73,7 @@ class IndexesWithBloatCheckOnClusterTest extends StatisticsAwareTestBase {
                     IndexWithBloat.of(ctx, clientsTableName, "clients_pkey"),
                     IndexWithBloat.of(ctx, clientsTableName, "i_clients_email_phone"))
                 .allMatch(i -> i.getIndexSizeInBytes() > 1L)
-                .allMatch(i -> i.getBloatSizeInBytes() > 1L && i.getBloatPercentage() >= 14);
+                .allMatch(i -> i.getBloatSizeInBytes() > 1L && i.getBloatPercentage() >= 8);
 
             assertThat(check)
                 .executing(ctx, SkipTablesByNamePredicate.of(ctx, List.of("accounts", "clients")))

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/StandardChecksOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/StandardChecksOnClusterTest.java
@@ -61,7 +61,8 @@ class StandardChecksOnClusterTest extends DatabaseAwareTestBase {
                 Diagnostic.BLOATED_TABLES,
                 Diagnostic.FOREIGN_KEYS_WITHOUT_INDEX,
                 Diagnostic.COLUMNS_WITH_FIXED_LENGTH_VARCHAR,
-                Diagnostic.COLUMNS_WITH_CHAR_TYPE
+                Diagnostic.COLUMNS_WITH_CHAR_TYPE,
+                Diagnostic.TABLES_WITH_NO_DATA
             )
             .map(Diagnostic::getName)
             .collect(Collectors.toUnmodifiableSet());

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithNoDataCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithNoDataCheckOnClusterTest.java
@@ -38,19 +38,23 @@ class TablesWithNoDataCheckOnClusterTest extends StatisticsAwareTestBase {
     @ParameterizedTest
     @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
     void onDatabaseWithThem(final String schemaName) {
-        executeTestOnDatabase(schemaName, dbp -> dbp.withEmptyTable().withData(), ctx -> {
+        executeTestOnDatabase(schemaName, dbp -> dbp.withEmptyTable().withBadlyNamedObjects().withData(), ctx -> {
             collectStatistics(schemaName);
 
             assertThat(check)
                 .executing(ctx)
-                .hasSize(1)
-                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("tableSizeInBytes")
-                .containsExactly(Table.of(ctx, "empty"))
-                .allMatch(t -> t.getTableSizeInBytes() >= 0L);
+                .hasSize(4)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields()
+                .containsExactly(
+                    Table.of(ctx, "\"bad-table\""),
+                    Table.of(ctx, "\"bad-table-two\"", 8_192L),
+                    Table.of(ctx, "empty"),
+                    Table.of(ctx, "\"UpperCaseTable\"")
+                );
 
             assertThat(check)
                 .executing(ctx, SkipTablesByNamePredicate.ofName(ctx, "empty"))
-                .isEmpty();
+                .hasSize(3);
         });
     }
 
@@ -65,6 +69,21 @@ class TablesWithNoDataCheckOnClusterTest extends StatisticsAwareTestBase {
                 .hasSize(1)
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("tableSizeInBytes")
                 .containsExactly(Table.of(ctx, "partitioned_table_with_no_data"))
+                .allMatch(t -> t.getTableSizeInBytes() >= 0L);
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
+    void shouldWorkWithLayeredPartitionedTables(final String schemaName) {
+        executeTestOnDatabase(schemaName, dbp -> dbp.withData().withLayeredPartitionedTables(), ctx -> {
+            collectStatistics(schemaName);
+
+            assertThat(check)
+                .executing(ctx)
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("tableSizeInBytes")
+                .containsExactly(Table.of(ctx, "two_level_partitioned_empty"))
                 .allMatch(t -> t.getTableSizeInBytes() >= 0L);
         });
     }

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithNoDataCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/TablesWithNoDataCheckOnClusterTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.health.checks.cluster;
+
+import io.github.mfvanek.pg.core.checks.common.Diagnostic;
+import io.github.mfvanek.pg.core.fixtures.support.StatisticsAwareTestBase;
+import io.github.mfvanek.pg.health.checks.common.DatabaseCheckOnCluster;
+import io.github.mfvanek.pg.model.context.PgContext;
+import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import io.github.mfvanek.pg.model.table.Table;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.assertThat;
+
+class TablesWithNoDataCheckOnClusterTest extends StatisticsAwareTestBase {
+
+    private final DatabaseCheckOnCluster<@NonNull Table> check = new TablesWithNoDataCheckOnCluster(getHaPgConnection());
+
+    @Test
+    void shouldSatisfyContract() {
+        assertThat(check)
+            .hasType(Table.class)
+            .hasDiagnostic(Diagnostic.TABLES_WITH_NO_DATA)
+            .isRuntime();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
+    void onDatabaseWithThem(final String schemaName) {
+        executeTestOnDatabase(schemaName, dbp -> dbp.withEmptyTable().withData(), ctx -> {
+            collectStatistics(schemaName);
+
+            assertThat(check)
+                .executing(ctx)
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("tableSizeInBytes")
+                .containsExactly(Table.of(ctx, "empty"))
+                .allMatch(t -> t.getTableSizeInBytes() >= 0L);
+
+            assertThat(check)
+                .executing(ctx, SkipTablesByNamePredicate.ofName(ctx, "empty"))
+                .isEmpty();
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
+    void shouldWorkWithPartitionedTables(final String schemaName) {
+        executeTestOnDatabase(schemaName, dbp -> dbp.withData().withEmptyPartitionedTable(), ctx -> {
+            collectStatistics(schemaName);
+
+            assertThat(check)
+                .executing(ctx)
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("tableSizeInBytes")
+                .containsExactly(Table.of(ctx, "partitioned_table_with_no_data"))
+                .allMatch(t -> t.getTableSizeInBytes() >= 0L);
+        });
+    }
+}

--- a/spring-boot-integration/pg-index-health-test-starter/src/main/java/io/github/mfvanek/pg/spring/DatabaseStructureChecksAutoConfiguration.java
+++ b/spring-boot-integration/pg-index-health-test-starter/src/main/java/io/github/mfvanek/pg/spring/DatabaseStructureChecksAutoConfiguration.java
@@ -47,6 +47,7 @@ import io.github.mfvanek.pg.core.checks.host.TablesWherePrimaryKeyColumnsNotFirs
 import io.github.mfvanek.pg.core.checks.host.TablesWithBloatCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithInheritanceCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithMissingIndexesCheckOnHost;
+import io.github.mfvanek.pg.core.checks.host.TablesWithNoDataCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithZeroOrOneColumnCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithoutDescriptionCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithoutPrimaryKeyCheckOnHost;
@@ -348,6 +349,13 @@ public class DatabaseStructureChecksAutoConfiguration {
     @ConditionalOnMissingBean
     public ForeignKeysWithNullValuesCheckOnHost foreignKeysWithNullValuesCheckOnHost(final PgConnection pgConnection) {
         return new ForeignKeysWithNullValuesCheckOnHost(pgConnection);
+    }
+
+    @Bean
+    @ConditionalOnClass(TablesWithNoDataCheckOnHost.class)
+    @ConditionalOnMissingBean
+    public TablesWithNoDataCheckOnHost tablesWithNoDataCheckOnHost(final PgConnection pgConnection) {
+        return new TablesWithNoDataCheckOnHost(pgConnection);
     }
 
     @Bean

--- a/spring-boot-integration/pg-index-health-test-starter/src/test/java/io/github/mfvanek/pg/spring/AutoConfigurationTestBase.java
+++ b/spring-boot-integration/pg-index-health-test-starter/src/test/java/io/github/mfvanek/pg/spring/AutoConfigurationTestBase.java
@@ -48,6 +48,7 @@ import io.github.mfvanek.pg.core.checks.host.TablesWherePrimaryKeyColumnsNotFirs
 import io.github.mfvanek.pg.core.checks.host.TablesWithBloatCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithInheritanceCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithMissingIndexesCheckOnHost;
+import io.github.mfvanek.pg.core.checks.host.TablesWithNoDataCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithZeroOrOneColumnCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithoutDescriptionCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWithoutPrimaryKeyCheckOnHost;
@@ -162,7 +163,8 @@ abstract class AutoConfigurationTestBase {
             TablesWhereAllColumnsNullableExceptPrimaryKeyCheckOnHost.class,
             ColumnsWithCharTypeCheckOnHost.class,
             TablesWithInheritanceCheckOnHost.class,
-            ForeignKeysWithNullValuesCheckOnHost.class
+            ForeignKeysWithNullValuesCheckOnHost.class,
+            TablesWithNoDataCheckOnHost.class
         );
     }
 }


### PR DESCRIPTION
Closes https://github.com/mfvanek/pg-index-health/issues/631

### Common steps

- [x] Read [CONTRIBUTING.md](https://github.com/mfvanek/pg-index-health/blob/master/CONTRIBUTING.md)
- [x] Linked to an issue
- [x] Added a description to PR

### For a database check

- [x] I have updated the [list of checks](https://github.com/mfvanek/pg-index-health/blob/master/doc/available_checks.md)
- [x] I have added the same tests for a check on host and a check on cluster
- [x] The check results are validated with `containsExactly()` and `usingRecursiveFieldByFieldElementComparator()`

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
