### PR TITLE
Add a check for tables where the foreign key self-references the primary key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,3 +128,7 @@ All production classes must be `@NullMarked` (package-level or class-level) and 
 | `config/forbidden-apis/forbidden-apis.txt` | Forbidden API calls |
 | `doc/available_checks.md` | Catalog of all checks with descriptions |
 | `doc/custom_checks.md` | Guide for writing custom user-defined checks |
+
+## Git workflow
+
+**Never create a git commit unless the user explicitly asks.** Make all file edits freely, but wait for an explicit instruction (e.g. "commit", "commit the changes") before running any `git commit` command.

--- a/doc/available_checks.md
+++ b/doc/available_checks.md
@@ -53,6 +53,7 @@ All checks can be divided into two groups:
 | 39 | Tables with [inheritance](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_table_inheritance)                          | static             | not applicable        | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_inheritance.sql)                     |
 | 40 | Multicolumn foreign keys where at least one of the referencing columns is nullable                                                 | static             | yes                   | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/foreign_keys_with_null_values.sql)               |
 | 41 | Tables with no data                                                                                                                | **runtime**        | yes                   | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_no_data.sql)                         |
+| 42 | Self-referenced foreign keys without `ON DELETE CASCADE` or `ON DELETE SET NULL`                                                   | static             | yes                   | [sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/self_referenced_foreign_keys.sql)                |
 
 ### Raw SQL queries to use with other languages
 

--- a/doc/eng/self_referenced_foreign_keys.md
+++ b/doc/eng/self_referenced_foreign_keys.md
@@ -39,7 +39,7 @@ create schema if not exists demo;
 
 -- A category tree: each category may have a parent category in the same table.
 -- The FK uses the default ON DELETE NO ACTION, which makes subtree deletion fragile.
-create table demo.bad_categories
+create table if not exists demo.bad_categories
 (
     id        bigint generated always as identity primary key,
     parent_id bigint,
@@ -49,16 +49,8 @@ create table demo.bad_categories
         -- ON DELETE NO ACTION is the implicit default; deleting a parent with children fails
 );
 
-insert into demo.bad_categories (parent_id, name) values (null, 'Root');
-insert into demo.bad_categories (parent_id, name) values (1, 'Child A');
-insert into demo.bad_categories (parent_id, name) values (1, 'Child B');
-
--- Attempting to delete the root row fails because child rows still reference it:
--- delete from demo.bad_categories where id = 1; -- ERROR: update or delete on table "bad_categories"
---                                                -- violates foreign key constraint
-
 -- A corrected version using ON DELETE CASCADE
-create table demo.good_categories_cascade
+create table if not exists demo.good_categories_cascade
 (
     id        bigint generated always as identity primary key,
     parent_id bigint,
@@ -68,17 +60,8 @@ create table demo.good_categories_cascade
         on delete cascade
 );
 
-insert into demo.good_categories_cascade (parent_id, name) values (null, 'Root');
-insert into demo.good_categories_cascade (parent_id, name) values (1, 'Child A');
-insert into demo.good_categories_cascade (parent_id, name) values (1, 'Child B');
-
--- Deleting the root row now automatically removes its children:
-delete from demo.good_categories_cascade where id = 1;
-
-table demo.good_categories_cascade; -- returns 0 rows
-
 -- A corrected version using ON DELETE SET NULL
-create table demo.good_categories_set_null
+create table if not exists demo.good_categories_set_null
 (
     id        bigint generated always as identity primary key,
     parent_id bigint, -- nullable: required for ON DELETE SET NULL
@@ -88,19 +71,10 @@ create table demo.good_categories_set_null
         on delete set null
 );
 
-insert into demo.good_categories_set_null (parent_id, name) values (null, 'Root');
-insert into demo.good_categories_set_null (parent_id, name) values (1, 'Child A');
-insert into demo.good_categories_set_null (parent_id, name) values (1, 'Child B');
-
--- Deleting the root row detaches its children (they become new roots):
-delete from demo.good_categories_set_null where id = 1;
-
-table demo.good_categories_set_null; -- returns 2 rows, both with parent_id = null
-
 -- Composite self-referenced FK example:
 -- A multi-tenant category tree where (tenant_id, category_id) is the composite primary key.
 -- A category's parent must belong to the same tenant, so the FK spans both columns.
-create table demo.bad_tenant_categories
+create table if not exists demo.bad_tenant_categories
 (
     tenant_id          integer not null,
     category_id        integer not null,
@@ -114,19 +88,8 @@ create table demo.bad_tenant_categories
     -- ON DELETE NO ACTION is the implicit default; deleting a parent with children fails
 );
 
-insert into demo.bad_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
-    values (1, 1, null, null, 'Root');
-insert into demo.bad_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
-    values (1, 2, 1, 1, 'Child A');
-insert into demo.bad_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
-    values (1, 3, 1, 1, 'Child B');
-
--- Attempting to delete the root row fails because child rows still reference it:
--- delete from demo.bad_tenant_categories where tenant_id = 1 and category_id = 1;
--- ERROR: update or delete on table "bad_tenant_categories" violates foreign key constraint
-
 -- A corrected version using ON DELETE CASCADE
-create table demo.good_tenant_categories
+create table if not exists demo.good_tenant_categories
 (
     tenant_id          integer not null,
     category_id        integer not null,
@@ -139,18 +102,6 @@ create table demo.good_tenant_categories
             references demo.good_tenant_categories (tenant_id, category_id)
             on delete cascade
 );
-
-insert into demo.good_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
-    values (1, 1, null, null, 'Root');
-insert into demo.good_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
-    values (1, 2, 1, 1, 'Child A');
-insert into demo.good_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
-    values (1, 3, 1, 1, 'Child B');
-
--- Deleting the root row automatically removes its children:
-delete from demo.good_tenant_categories where tenant_id = 1 and category_id = 1;
-
-table demo.good_tenant_categories; -- returns 0 rows
 ```
 
 ## How to fix

--- a/doc/eng/self_referenced_foreign_keys.md
+++ b/doc/eng/self_referenced_foreign_keys.md
@@ -1,0 +1,120 @@
+# Check for self-referenced foreign keys without `ON DELETE CASCADE` or `ON DELETE SET NULL`
+
+A self-referenced foreign key (a.k.a. recursive or self-join foreign key) is a constraint where
+a table's foreign key column references the primary key of the same table.
+This pattern is commonly used to model hierarchical or tree-structured data:
+category trees, organizational charts, threaded comments, bill-of-materials, etc.
+
+When the `ON DELETE` action is `NO ACTION` (the PostgreSQL default when no rule is specified) or `RESTRICT`,
+deleting a parent row that is still referenced by child rows will fail with a foreign key violation error.
+To remove a node from such a hierarchy the application must first recursively delete or re-parent
+all descendants — which requires complex application logic and careful transaction ordering.
+In high-concurrency scenarios this also significantly increases the risk of deadlocks.
+
+Preferred alternatives:
+- `ON DELETE CASCADE` — automatically removes all descendant rows when a parent is deleted;
+  safe when the entire subtree should be removed together.
+- `ON DELETE SET NULL` — sets the FK column to `NULL` in child rows, detaching them from the deleted parent
+  and turning them into new root nodes; requires the FK column to be nullable.
+
+See details in the [official documentation](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK).
+
+## SQL query
+
+- [self_referenced_foreign_keys.sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/self_referenced_foreign_keys.sql)
+
+## Check type
+
+- **static** (can be performed on an empty database in component/integration tests)
+
+## Support for partitioned tables
+
+Supports partitioned tables.
+The check is performed on the partitioned table itself (the parent one). Individual sections (descendants) are ignored.
+
+## Reproduction script
+
+```sql
+create schema if not exists demo;
+
+-- A category tree: each category may have a parent category in the same table.
+-- The FK uses the default ON DELETE NO ACTION, which makes subtree deletion fragile.
+create table demo.bad_categories
+(
+    id        bigint generated always as identity primary key,
+    parent_id bigint,
+    name      text not null,
+    constraint bad_categories_parent_fk
+        foreign key (parent_id) references demo.bad_categories (id)
+        -- ON DELETE NO ACTION is the implicit default; deleting a parent with children fails
+);
+
+insert into demo.bad_categories (parent_id, name) values (null, 'Root');
+insert into demo.bad_categories (parent_id, name) values (1, 'Child A');
+insert into demo.bad_categories (parent_id, name) values (1, 'Child B');
+
+-- Attempting to delete the root row fails because child rows still reference it:
+-- delete from demo.bad_categories where id = 1; -- ERROR: update or delete on table "bad_categories"
+--                                                -- violates foreign key constraint
+
+-- A corrected version using ON DELETE CASCADE
+create table demo.good_categories_cascade
+(
+    id        bigint generated always as identity primary key,
+    parent_id bigint,
+    name      text not null,
+    constraint good_categories_cascade_parent_fk
+        foreign key (parent_id) references demo.good_categories_cascade (id)
+        on delete cascade
+);
+
+insert into demo.good_categories_cascade (parent_id, name) values (null, 'Root');
+insert into demo.good_categories_cascade (parent_id, name) values (1, 'Child A');
+insert into demo.good_categories_cascade (parent_id, name) values (1, 'Child B');
+
+-- Deleting the root row now automatically removes its children:
+delete from demo.good_categories_cascade where id = 1;
+
+table demo.good_categories_cascade; -- returns 0 rows
+
+-- A corrected version using ON DELETE SET NULL
+create table demo.good_categories_set_null
+(
+    id        bigint generated always as identity primary key,
+    parent_id bigint, -- nullable: required for ON DELETE SET NULL
+    name      text not null,
+    constraint good_categories_set_null_parent_fk
+        foreign key (parent_id) references demo.good_categories_set_null (id)
+        on delete set null
+);
+
+insert into demo.good_categories_set_null (parent_id, name) values (null, 'Root');
+insert into demo.good_categories_set_null (parent_id, name) values (1, 'Child A');
+insert into demo.good_categories_set_null (parent_id, name) values (1, 'Child B');
+
+-- Deleting the root row detaches its children (they become new roots):
+delete from demo.good_categories_set_null where id = 1;
+
+table demo.good_categories_set_null; -- returns 2 rows, both with parent_id = null
+```
+
+## How to fix
+
+Add an explicit `ON DELETE` action to the self-referencing foreign key constraint.
+
+Choose the action based on the desired semantics:
+- Use `ON DELETE CASCADE` when removing a parent should automatically remove all its descendants.
+- Use `ON DELETE SET NULL` when removing a parent should detach its children, making them independent root nodes.
+  The FK column must be nullable for this option.
+
+To alter an existing constraint, drop and recreate it:
+
+```sql
+alter table demo.bad_categories
+    drop constraint bad_categories_parent_fk;
+
+alter table demo.bad_categories
+    add constraint bad_categories_parent_fk
+        foreign key (parent_id) references demo.bad_categories (id)
+        on delete cascade;
+```

--- a/doc/eng/self_referenced_foreign_keys.md
+++ b/doc/eng/self_referenced_foreign_keys.md
@@ -96,6 +96,61 @@ insert into demo.good_categories_set_null (parent_id, name) values (1, 'Child B'
 delete from demo.good_categories_set_null where id = 1;
 
 table demo.good_categories_set_null; -- returns 2 rows, both with parent_id = null
+
+-- Composite self-referenced FK example:
+-- A multi-tenant category tree where (tenant_id, category_id) is the composite primary key.
+-- A category's parent must belong to the same tenant, so the FK spans both columns.
+create table demo.bad_tenant_categories
+(
+    tenant_id          integer not null,
+    category_id        integer not null,
+    parent_tenant_id   integer,
+    parent_category_id integer,
+    name               text not null,
+    primary key (tenant_id, category_id),
+    constraint bad_tenant_categories_parent_fk
+        foreign key (parent_tenant_id, parent_category_id)
+            references demo.bad_tenant_categories (tenant_id, category_id)
+    -- ON DELETE NO ACTION is the implicit default; deleting a parent with children fails
+);
+
+insert into demo.bad_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
+    values (1, 1, null, null, 'Root');
+insert into demo.bad_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
+    values (1, 2, 1, 1, 'Child A');
+insert into demo.bad_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
+    values (1, 3, 1, 1, 'Child B');
+
+-- Attempting to delete the root row fails because child rows still reference it:
+-- delete from demo.bad_tenant_categories where tenant_id = 1 and category_id = 1;
+-- ERROR: update or delete on table "bad_tenant_categories" violates foreign key constraint
+
+-- A corrected version using ON DELETE CASCADE
+create table demo.good_tenant_categories
+(
+    tenant_id          integer not null,
+    category_id        integer not null,
+    parent_tenant_id   integer,
+    parent_category_id integer,
+    name               text not null,
+    primary key (tenant_id, category_id),
+    constraint good_tenant_categories_parent_fk
+        foreign key (parent_tenant_id, parent_category_id)
+            references demo.good_tenant_categories (tenant_id, category_id)
+            on delete cascade
+);
+
+insert into demo.good_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
+    values (1, 1, null, null, 'Root');
+insert into demo.good_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
+    values (1, 2, 1, 1, 'Child A');
+insert into demo.good_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
+    values (1, 3, 1, 1, 'Child B');
+
+-- Deleting the root row automatically removes its children:
+delete from demo.good_tenant_categories where tenant_id = 1 and category_id = 1;
+
+table demo.good_tenant_categories; -- returns 0 rows
 ```
 
 ## How to fix

--- a/doc/eng/self_referenced_foreign_keys.md
+++ b/doc/eng/self_referenced_foreign_keys.md
@@ -102,6 +102,42 @@ create table if not exists demo.good_tenant_categories
             references demo.good_tenant_categories (tenant_id, category_id)
             on delete cascade
 );
+
+-- Partitioned table example:
+-- Using hash partitioning on id so that id alone can serve as the primary key,
+-- allowing the self-referencing FK to reference id without including the partition key.
+create table if not exists demo.bad_categories_partitioned
+(
+    id        bigint not null,
+    parent_id bigint,
+    name      text not null,
+    primary key (id),
+    constraint bad_categories_partitioned_parent_fk
+        foreign key (parent_id) references demo.bad_categories_partitioned (id)
+        -- ON DELETE NO ACTION is the implicit default; deleting a parent with children fails
+) partition by hash (id);
+
+create table if not exists demo.bad_categories_partitioned_0
+    partition of demo.bad_categories_partitioned for values with (modulus 2, remainder 0);
+create table if not exists demo.bad_categories_partitioned_1
+    partition of demo.bad_categories_partitioned for values with (modulus 2, remainder 1);
+
+-- A corrected version using ON DELETE CASCADE
+create table if not exists demo.good_categories_partitioned
+(
+    id        bigint not null,
+    parent_id bigint,
+    name      text not null,
+    primary key (id),
+    constraint good_categories_partitioned_parent_fk
+        foreign key (parent_id) references demo.good_categories_partitioned (id)
+            on delete cascade
+) partition by hash (id);
+
+create table if not exists demo.good_categories_partitioned_0
+    partition of demo.good_categories_partitioned for values with (modulus 2, remainder 0);
+create table if not exists demo.good_categories_partitioned_1
+    partition of demo.good_categories_partitioned for values with (modulus 2, remainder 1);
 ```
 
 ## How to fix

--- a/doc/rus/self_referenced_foreign_keys.md
+++ b/doc/rus/self_referenced_foreign_keys.md
@@ -96,6 +96,61 @@ insert into demo.good_categories_set_null (parent_id, name) values (1, 'Child B'
 delete from demo.good_categories_set_null where id = 1;
 
 table demo.good_categories_set_null; -- возвращает 2 строки, обе с parent_id = null
+
+-- Пример составного самоссылающегося внешнего ключа:
+-- Мультитенантное дерево категорий, где (tenant_id, category_id) — составной первичный ключ.
+-- Родительская категория должна принадлежать тому же тенанту, поэтому FK охватывает оба столбца.
+create table demo.bad_tenant_categories
+(
+    tenant_id          integer not null,
+    category_id        integer not null,
+    parent_tenant_id   integer,
+    parent_category_id integer,
+    name               text not null,
+    primary key (tenant_id, category_id),
+    constraint bad_tenant_categories_parent_fk
+        foreign key (parent_tenant_id, parent_category_id)
+            references demo.bad_tenant_categories (tenant_id, category_id)
+    -- ON DELETE NO ACTION — неявное умолчание; удаление родителя с дочерними строками завершается ошибкой
+);
+
+insert into demo.bad_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
+    values (1, 1, null, null, 'Root');
+insert into demo.bad_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
+    values (1, 2, 1, 1, 'Child A');
+insert into demo.bad_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
+    values (1, 3, 1, 1, 'Child B');
+
+-- Попытка удалить корневую строку завершится ошибкой, т. к. дочерние строки ещё ссылаются на неё:
+-- delete from demo.bad_tenant_categories where tenant_id = 1 and category_id = 1;
+-- ERROR: update or delete on table "bad_tenant_categories" violates foreign key constraint
+
+-- Исправленный вариант с ON DELETE CASCADE
+create table demo.good_tenant_categories
+(
+    tenant_id          integer not null,
+    category_id        integer not null,
+    parent_tenant_id   integer,
+    parent_category_id integer,
+    name               text not null,
+    primary key (tenant_id, category_id),
+    constraint good_tenant_categories_parent_fk
+        foreign key (parent_tenant_id, parent_category_id)
+            references demo.good_tenant_categories (tenant_id, category_id)
+            on delete cascade
+);
+
+insert into demo.good_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
+    values (1, 1, null, null, 'Root');
+insert into demo.good_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
+    values (1, 2, 1, 1, 'Child A');
+insert into demo.good_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
+    values (1, 3, 1, 1, 'Child B');
+
+-- Удаление корневой строки автоматически удаляет всех её потомков:
+delete from demo.good_tenant_categories where tenant_id = 1 and category_id = 1;
+
+table demo.good_tenant_categories; -- возвращает 0 строк
 ```
 
 ## Как исправить

--- a/doc/rus/self_referenced_foreign_keys.md
+++ b/doc/rus/self_referenced_foreign_keys.md
@@ -102,6 +102,42 @@ create table if not exists demo.good_tenant_categories
             references demo.good_tenant_categories (tenant_id, category_id)
             on delete cascade
 );
+
+-- Пример с секционированной таблицей:
+-- Используем хеш-секционирование по id, что позволяет использовать id как единственный первичный ключ.
+-- Благодаря этому самоссылающийся FK может ссылаться только на id, не включая ключ секционирования.
+create table if not exists demo.bad_categories_partitioned
+(
+    id        bigint not null,
+    parent_id bigint,
+    name      text not null,
+    primary key (id),
+    constraint bad_categories_partitioned_parent_fk
+        foreign key (parent_id) references demo.bad_categories_partitioned (id)
+        -- ON DELETE NO ACTION — неявное умолчание; удаление родителя с дочерними строками завершается ошибкой
+) partition by hash (id);
+
+create table if not exists demo.bad_categories_partitioned_0
+    partition of demo.bad_categories_partitioned for values with (modulus 2, remainder 0);
+create table if not exists demo.bad_categories_partitioned_1
+    partition of demo.bad_categories_partitioned for values with (modulus 2, remainder 1);
+
+-- Исправленный вариант с ON DELETE CASCADE
+create table if not exists demo.good_categories_partitioned
+(
+    id        bigint not null,
+    parent_id bigint,
+    name      text not null,
+    primary key (id),
+    constraint good_categories_partitioned_parent_fk
+        foreign key (parent_id) references demo.good_categories_partitioned (id)
+            on delete cascade
+) partition by hash (id);
+
+create table if not exists demo.good_categories_partitioned_0
+    partition of demo.good_categories_partitioned for values with (modulus 2, remainder 0);
+create table if not exists demo.good_categories_partitioned_1
+    partition of demo.good_categories_partitioned for values with (modulus 2, remainder 1);
 ```
 
 ## Как исправить

--- a/doc/rus/self_referenced_foreign_keys.md
+++ b/doc/rus/self_referenced_foreign_keys.md
@@ -39,7 +39,7 @@ create schema if not exists demo;
 
 -- Дерево категорий: каждая категория может иметь родительскую категорию в той же таблице.
 -- FK использует ON DELETE NO ACTION по умолчанию, что делает удаление поддерева ненадёжным.
-create table demo.bad_categories
+create table if not exists demo.bad_categories
 (
     id        bigint generated always as identity primary key,
     parent_id bigint,
@@ -49,16 +49,8 @@ create table demo.bad_categories
         -- ON DELETE NO ACTION — неявное умолчание; удаление родителя с дочерними строками завершается ошибкой
 );
 
-insert into demo.bad_categories (parent_id, name) values (null, 'Root');
-insert into demo.bad_categories (parent_id, name) values (1, 'Child A');
-insert into demo.bad_categories (parent_id, name) values (1, 'Child B');
-
--- Попытка удалить корневую строку завершится ошибкой, т. к. дочерние строки ещё ссылаются на неё:
--- delete from demo.bad_categories where id = 1; -- ERROR: update or delete on table "bad_categories"
---                                                -- violates foreign key constraint
-
 -- Исправленный вариант с ON DELETE CASCADE
-create table demo.good_categories_cascade
+create table if not exists demo.good_categories_cascade
 (
     id        bigint generated always as identity primary key,
     parent_id bigint,
@@ -68,17 +60,8 @@ create table demo.good_categories_cascade
         on delete cascade
 );
 
-insert into demo.good_categories_cascade (parent_id, name) values (null, 'Root');
-insert into demo.good_categories_cascade (parent_id, name) values (1, 'Child A');
-insert into demo.good_categories_cascade (parent_id, name) values (1, 'Child B');
-
--- Удаление корневой строки автоматически удаляет всех её потомков:
-delete from demo.good_categories_cascade where id = 1;
-
-table demo.good_categories_cascade; -- возвращает 0 строк
-
 -- Исправленный вариант с ON DELETE SET NULL
-create table demo.good_categories_set_null
+create table if not exists demo.good_categories_set_null
 (
     id        bigint generated always as identity primary key,
     parent_id bigint, -- nullable: обязательно для ON DELETE SET NULL
@@ -88,19 +71,10 @@ create table demo.good_categories_set_null
         on delete set null
 );
 
-insert into demo.good_categories_set_null (parent_id, name) values (null, 'Root');
-insert into demo.good_categories_set_null (parent_id, name) values (1, 'Child A');
-insert into demo.good_categories_set_null (parent_id, name) values (1, 'Child B');
-
--- Удаление корневой строки отвязывает её дочерние элементы (они становятся новыми корнями):
-delete from demo.good_categories_set_null where id = 1;
-
-table demo.good_categories_set_null; -- возвращает 2 строки, обе с parent_id = null
-
 -- Пример составного самоссылающегося внешнего ключа:
 -- Мультитенантное дерево категорий, где (tenant_id, category_id) — составной первичный ключ.
 -- Родительская категория должна принадлежать тому же тенанту, поэтому FK охватывает оба столбца.
-create table demo.bad_tenant_categories
+create table if not exists demo.bad_tenant_categories
 (
     tenant_id          integer not null,
     category_id        integer not null,
@@ -114,19 +88,8 @@ create table demo.bad_tenant_categories
     -- ON DELETE NO ACTION — неявное умолчание; удаление родителя с дочерними строками завершается ошибкой
 );
 
-insert into demo.bad_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
-    values (1, 1, null, null, 'Root');
-insert into demo.bad_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
-    values (1, 2, 1, 1, 'Child A');
-insert into demo.bad_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
-    values (1, 3, 1, 1, 'Child B');
-
--- Попытка удалить корневую строку завершится ошибкой, т. к. дочерние строки ещё ссылаются на неё:
--- delete from demo.bad_tenant_categories where tenant_id = 1 and category_id = 1;
--- ERROR: update or delete on table "bad_tenant_categories" violates foreign key constraint
-
 -- Исправленный вариант с ON DELETE CASCADE
-create table demo.good_tenant_categories
+create table if not exists demo.good_tenant_categories
 (
     tenant_id          integer not null,
     category_id        integer not null,
@@ -139,18 +102,6 @@ create table demo.good_tenant_categories
             references demo.good_tenant_categories (tenant_id, category_id)
             on delete cascade
 );
-
-insert into demo.good_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
-    values (1, 1, null, null, 'Root');
-insert into demo.good_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
-    values (1, 2, 1, 1, 'Child A');
-insert into demo.good_tenant_categories (tenant_id, category_id, parent_tenant_id, parent_category_id, name)
-    values (1, 3, 1, 1, 'Child B');
-
--- Удаление корневой строки автоматически удаляет всех её потомков:
-delete from demo.good_tenant_categories where tenant_id = 1 and category_id = 1;
-
-table demo.good_tenant_categories; -- возвращает 0 строк
 ```
 
 ## Как исправить

--- a/doc/rus/self_referenced_foreign_keys.md
+++ b/doc/rus/self_referenced_foreign_keys.md
@@ -1,0 +1,120 @@
+# Проверка наличия самоссылающихся внешних ключей без `ON DELETE CASCADE` или `ON DELETE SET NULL`
+
+Самоссылающийся внешний ключ (рекурсивный или self-join FK) — это ограничение, при котором
+столбец внешнего ключа таблицы ссылается на первичный ключ той же самой таблицы.
+Этот шаблон часто используется для моделирования иерархических или древовидных структур данных:
+деревья категорий, организационные схемы, ветки комментариев, спецификации изделий и т. п.
+
+Когда для `ON DELETE` указано действие `NO ACTION` (поведение PostgreSQL по умолчанию, если правило не задано) или `RESTRICT`,
+попытка удалить родительскую строку, на которую ссылаются дочерние строки, завершится ошибкой нарушения внешнего ключа.
+Чтобы удалить узел из такой иерархии, приложение должно сначала рекурсивно удалить или перепривязать
+всех потомков — что требует сложной логики и тщательного порядка выполнения транзакций.
+В условиях высокой конкурентности это также существенно повышает риск взаимных блокировок (deadlock).
+
+Предпочтительные альтернативы:
+- `ON DELETE CASCADE` — автоматически удаляет все дочерние строки при удалении родителя;
+  безопасен, когда всё поддерево должно удаляться вместе с родителем.
+- `ON DELETE SET NULL` — устанавливает `NULL` в FK-столбце дочерних строк, отвязывая их от удалённого родителя
+  и превращая в новые корневые узлы; требует, чтобы FK-столбец допускал `NULL`.
+
+Подробности в [официальной документации](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK).
+
+## SQL запрос
+
+- [self_referenced_foreign_keys.sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/self_referenced_foreign_keys.sql)
+
+## Тип проверки
+
+- **static** (может выполняться на пустой БД в компонентных\интеграционных тестах)
+
+## Поддержка секционированных таблиц
+
+Поддерживает секционированные таблицы.
+Проверка выполняется на самой секционированной таблице (родительской). Отдельные секции (потомки) игнорируются.
+
+## Скрипт для воспроизведения
+
+```sql
+create schema if not exists demo;
+
+-- Дерево категорий: каждая категория может иметь родительскую категорию в той же таблице.
+-- FK использует ON DELETE NO ACTION по умолчанию, что делает удаление поддерева ненадёжным.
+create table demo.bad_categories
+(
+    id        bigint generated always as identity primary key,
+    parent_id bigint,
+    name      text not null,
+    constraint bad_categories_parent_fk
+        foreign key (parent_id) references demo.bad_categories (id)
+        -- ON DELETE NO ACTION — неявное умолчание; удаление родителя с дочерними строками завершается ошибкой
+);
+
+insert into demo.bad_categories (parent_id, name) values (null, 'Root');
+insert into demo.bad_categories (parent_id, name) values (1, 'Child A');
+insert into demo.bad_categories (parent_id, name) values (1, 'Child B');
+
+-- Попытка удалить корневую строку завершится ошибкой, т. к. дочерние строки ещё ссылаются на неё:
+-- delete from demo.bad_categories where id = 1; -- ERROR: update or delete on table "bad_categories"
+--                                                -- violates foreign key constraint
+
+-- Исправленный вариант с ON DELETE CASCADE
+create table demo.good_categories_cascade
+(
+    id        bigint generated always as identity primary key,
+    parent_id bigint,
+    name      text not null,
+    constraint good_categories_cascade_parent_fk
+        foreign key (parent_id) references demo.good_categories_cascade (id)
+        on delete cascade
+);
+
+insert into demo.good_categories_cascade (parent_id, name) values (null, 'Root');
+insert into demo.good_categories_cascade (parent_id, name) values (1, 'Child A');
+insert into demo.good_categories_cascade (parent_id, name) values (1, 'Child B');
+
+-- Удаление корневой строки автоматически удаляет всех её потомков:
+delete from demo.good_categories_cascade where id = 1;
+
+table demo.good_categories_cascade; -- возвращает 0 строк
+
+-- Исправленный вариант с ON DELETE SET NULL
+create table demo.good_categories_set_null
+(
+    id        bigint generated always as identity primary key,
+    parent_id bigint, -- nullable: обязательно для ON DELETE SET NULL
+    name      text not null,
+    constraint good_categories_set_null_parent_fk
+        foreign key (parent_id) references demo.good_categories_set_null (id)
+        on delete set null
+);
+
+insert into demo.good_categories_set_null (parent_id, name) values (null, 'Root');
+insert into demo.good_categories_set_null (parent_id, name) values (1, 'Child A');
+insert into demo.good_categories_set_null (parent_id, name) values (1, 'Child B');
+
+-- Удаление корневой строки отвязывает её дочерние элементы (они становятся новыми корнями):
+delete from demo.good_categories_set_null where id = 1;
+
+table demo.good_categories_set_null; -- возвращает 2 строки, обе с parent_id = null
+```
+
+## Как исправить
+
+Добавьте явное действие `ON DELETE` к самоссылающемуся ограничению внешнего ключа.
+
+Выберите действие в зависимости от нужной семантики:
+- Используйте `ON DELETE CASCADE`, если удаление родителя должно автоматически удалять всех его потомков.
+- Используйте `ON DELETE SET NULL`, если удаление родителя должно отвязывать его детей, делая их независимыми корневыми узлами.
+  Для этого варианта FK-столбец должен допускать `NULL`.
+
+Чтобы изменить существующее ограничение, удалите его и создайте заново:
+
+```sql
+alter table demo.bad_categories
+    drop constraint bad_categories_parent_fk;
+
+alter table demo.bad_categories
+    add constraint bad_categories_parent_fk
+        foreign key (parent_id) references demo.bad_categories (id)
+        on delete cascade;
+```

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/Diagnostic.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/common/Diagnostic.java
@@ -188,7 +188,11 @@ public enum Diagnostic implements CheckInfo {
     /**
      * Check for tables with no data.
      */
-    TABLES_WITH_NO_DATA(StandardCheckInfo::ofRuntime);
+    TABLES_WITH_NO_DATA(StandardCheckInfo::ofRuntime),
+    /**
+     * Check for self-referenced foreign keys without {@code ON DELETE CASCADE} or {@code ON DELETE SET NULL}.
+     */
+    SELF_REFERENCED_FOREIGN_KEYS;
 
     private final CheckInfo inner;
 

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/SelfReferencedForeignKeysCheckOnHost.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/SelfReferencedForeignKeysCheckOnHost.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.core.checks.host;
+
+import io.github.mfvanek.pg.connection.PgConnection;
+import io.github.mfvanek.pg.core.checks.common.Diagnostic;
+import io.github.mfvanek.pg.core.checks.extractors.ForeignKeyExtractor;
+import io.github.mfvanek.pg.model.constraint.ForeignKey;
+
+/**
+ * Check for self-referenced foreign keys without {@code ON DELETE CASCADE} or {@code ON DELETE SET NULL} on a specific host.
+ *
+ * @author Ivan Vakhrushev
+ * @since 0.41.1
+ */
+public class SelfReferencedForeignKeysCheckOnHost extends AbstractCheckOnHost<ForeignKey> {
+
+    /**
+     * Constructs a new instance of {@code SelfReferencedForeignKeysCheckOnHost}.
+     *
+     * @param pgConnection the connection to the PostgreSQL database; must not be null
+     */
+    public SelfReferencedForeignKeysCheckOnHost(final PgConnection pgConnection) {
+        super(ForeignKey.class, pgConnection, Diagnostic.SELF_REFERENCED_FOREIGN_KEYS, ForeignKeyExtractor.ofDefault());
+    }
+}

--- a/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/StandardChecksOnHost.java
+++ b/pg-index-health-core/src/main/java/io/github/mfvanek/pg/core/checks/host/StandardChecksOnHost.java
@@ -83,7 +83,8 @@ public final class StandardChecksOnHost implements Function<PgConnection, List<D
             new ColumnsWithCharTypeCheckOnHost(pgConnection),
             new TablesWithInheritanceCheckOnHost(pgConnection),
             new ForeignKeysWithNullValuesCheckOnHost(pgConnection),
-            new TablesWithNoDataCheckOnHost(pgConnection)
+            new TablesWithNoDataCheckOnHost(pgConnection),
+            new SelfReferencedForeignKeysCheckOnHost(pgConnection)
         );
     }
 }

--- a/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/SelfReferencedForeignKeysCheckOnHostTest.java
+++ b/pg-index-health-core/src/test/java/io/github/mfvanek/pg/core/checks/host/SelfReferencedForeignKeysCheckOnHostTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.core.checks.host;
+
+import io.github.mfvanek.pg.core.checks.common.DatabaseCheckOnHost;
+import io.github.mfvanek.pg.core.checks.common.Diagnostic;
+import io.github.mfvanek.pg.core.fixtures.support.DatabaseAwareTestBase;
+import io.github.mfvanek.pg.core.fixtures.support.DatabasePopulator;
+import io.github.mfvanek.pg.model.constraint.ForeignKey;
+import io.github.mfvanek.pg.model.context.PgContext;
+import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+import static io.github.mfvanek.pg.core.support.AbstractCheckOnHostAssert.assertThat;
+
+class SelfReferencedForeignKeysCheckOnHostTest extends DatabaseAwareTestBase {
+
+    private final DatabaseCheckOnHost<@NonNull ForeignKey> check = new SelfReferencedForeignKeysCheckOnHost(getPgConnection());
+
+    @Test
+    void shouldSatisfyContract() {
+        assertThat(check)
+            .hasType(ForeignKey.class)
+            .hasDiagnostic(Diagnostic.SELF_REFERENCED_FOREIGN_KEYS)
+            .hasHost(getHost())
+            .isStatic();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
+    void onDatabaseWithThem(final String schemaName) {
+        executeTestOnDatabase(schemaName, DatabasePopulator::withSelfReferencedForeignKeys, ctx -> {
+            assertThat(check)
+                .executing(ctx)
+                .hasSize(2)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(
+                    ForeignKey.ofNullableColumn(ctx, "bad_self_ref_restrict_table", "bad_self_ref_restrict_table_parent_id_fk", "parent_id"),
+                    ForeignKey.ofNullableColumn(ctx, "bad_self_ref_table", "bad_self_ref_table_parent_id_fk", "parent_id")
+                );
+
+            assertThat(check)
+                .executing(ctx, SkipTablesByNamePredicate.of(ctx, List.of("bad_self_ref_table", "bad_self_ref_restrict_table")))
+                .isEmpty();
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
+    void shouldWorkWithPartitionedTables(final String schemaName) {
+        executeTestOnDatabase(schemaName, DatabasePopulator::withSelfReferencedForeignKeysInPartitionedTable, ctx -> {
+            assertThat(check)
+                .executing(ctx)
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(
+                    ForeignKey.ofNullableColumn(ctx, "bad_self_ref_partitioned", "bad_self_ref_partitioned_parent_id_fk", "parent_id")
+                );
+        });
+    }
+}

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
@@ -19,8 +19,6 @@ import io.github.mfvanek.pg.core.fixtures.support.statements.AddCommentOnFunctio
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddCommentOnProceduresStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddCommentOnTablesStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddCompositeForeignKeyWithNullValuesStatement;
-import io.github.mfvanek.pg.core.fixtures.support.statements.AddSelfReferencedForeignKeysStatement;
-import io.github.mfvanek.pg.core.fixtures.support.statements.AddSelfReferencedForeignKeysToPartitionedTableStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddCompositeForeignKeyWithNullValuesToPartitionedTableStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddDuplicatedForeignKeysStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddDuplicatedForeignKeysToPartitionedTableStatement;
@@ -31,6 +29,8 @@ import io.github.mfvanek.pg.core.fixtures.support.statements.AddLinksBetweenAcco
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddMoneyColumnStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddNotValidConstraintToPartitionedTableStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddPrimaryKeyForDefaultPartitionStatement;
+import io.github.mfvanek.pg.core.fixtures.support.statements.AddSelfReferencedForeignKeysStatement;
+import io.github.mfvanek.pg.core.fixtures.support.statements.AddSelfReferencedForeignKeysToPartitionedTableStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.ConvertColumnToJsonTypeStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreateAccountsTableStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.CreateBadlyNamedObjectsStatement;

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
@@ -19,6 +19,8 @@ import io.github.mfvanek.pg.core.fixtures.support.statements.AddCommentOnFunctio
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddCommentOnProceduresStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddCommentOnTablesStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddCompositeForeignKeyWithNullValuesStatement;
+import io.github.mfvanek.pg.core.fixtures.support.statements.AddSelfReferencedForeignKeysStatement;
+import io.github.mfvanek.pg.core.fixtures.support.statements.AddSelfReferencedForeignKeysToPartitionedTableStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddCompositeForeignKeyWithNullValuesToPartitionedTableStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddDuplicatedForeignKeysStatement;
 import io.github.mfvanek.pg.core.fixtures.support.statements.AddDuplicatedForeignKeysToPartitionedTableStatement;
@@ -403,6 +405,14 @@ public final class DatabasePopulator implements AutoCloseable {
 
     public DatabasePopulator withLayeredPartitionedTables() {
         return register(150, new CreateLayeredPartitionedTablesStatement());
+    }
+
+    public DatabasePopulator withSelfReferencedForeignKeys() {
+        return register(151, new AddSelfReferencedForeignKeysStatement());
+    }
+
+    public DatabasePopulator withSelfReferencedForeignKeysInPartitionedTable() {
+        return register(152, new AddSelfReferencedForeignKeysToPartitionedTableStatement());
     }
 
     public void populate() {

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/DatabasePopulator.java
@@ -93,7 +93,7 @@ import java.util.Objects;
 import java.util.TreeMap;
 import javax.sql.DataSource;
 
-@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity", "PMD.ExcessivePublicCount"})
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity", "PMD.ExcessivePublicCount", "PMD.CyclomaticComplexity"})
 public final class DatabasePopulator implements AutoCloseable {
 
     private final DataSource dataSource;

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/AddSelfReferencedForeignKeysStatement.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/AddSelfReferencedForeignKeysStatement.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.core.fixtures.support.statements;
+
+import java.util.List;
+
+public class AddSelfReferencedForeignKeysStatement extends AbstractDbStatement {
+
+    @Override
+    protected List<String> getSqlToExecute() {
+        return List.of(
+            """
+                create table {schemaName}.bad_self_ref_table (
+                    id bigint generated always as identity primary key,
+                    parent_id bigint,
+                    name text not null,
+                    constraint bad_self_ref_table_parent_id_fk
+                        foreign key (parent_id) references {schemaName}.bad_self_ref_table (id)
+                );""",
+            """
+                create table {schemaName}.bad_self_ref_restrict_table (
+                    id bigint generated always as identity primary key,
+                    parent_id bigint,
+                    name text not null,
+                    constraint bad_self_ref_restrict_table_parent_id_fk
+                        foreign key (parent_id) references {schemaName}.bad_self_ref_restrict_table (id)
+                        on delete restrict
+                );""",
+            """
+                create table {schemaName}.good_self_ref_table (
+                    id bigint generated always as identity primary key,
+                    parent_id bigint,
+                    name text not null,
+                    constraint good_self_ref_table_parent_id_fk
+                        foreign key (parent_id) references {schemaName}.good_self_ref_table (id)
+                        on delete cascade
+                );"""
+        );
+    }
+}

--- a/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/AddSelfReferencedForeignKeysToPartitionedTableStatement.java
+++ b/pg-index-health-core/src/testFixtures/java/io/github/mfvanek/pg/core/fixtures/support/statements/AddSelfReferencedForeignKeysToPartitionedTableStatement.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.core.fixtures.support.statements;
+
+import java.util.List;
+
+public class AddSelfReferencedForeignKeysToPartitionedTableStatement extends AbstractDbStatement {
+
+    @Override
+    protected List<String> getSqlToExecute() {
+        return List.of(
+            """
+                create table if not exists {schemaName}.bad_self_ref_partitioned (
+                    id bigint not null,
+                    parent_id bigint,
+                    name text not null,
+                    primary key (id),
+                    constraint bad_self_ref_partitioned_parent_id_fk
+                        foreign key (parent_id) references {schemaName}.bad_self_ref_partitioned (id)
+                ) partition by hash (id);""",
+            """
+                create table if not exists {schemaName}.bad_self_ref_partitioned_0
+                    partition of {schemaName}.bad_self_ref_partitioned for values with (modulus 2, remainder 0);""",
+            """
+                create table if not exists {schemaName}.bad_self_ref_partitioned_1
+                    partition of {schemaName}.bad_self_ref_partitioned for values with (modulus 2, remainder 1);"""
+        );
+    }
+}

--- a/pg-index-health-logger/src/test/java/io/github/mfvanek/pg/health/logger/StandardHealthLoggerTest.java
+++ b/pg-index-health-logger/src/test/java/io/github/mfvanek/pg/health/logger/StandardHealthLoggerTest.java
@@ -133,7 +133,8 @@ class StandardHealthLoggerTest extends StatisticsAwareTestBase {
                         "columns_with_char_type:4",
                         "tables_with_inheritance:0",
                         "foreign_keys_with_null_values:1",
-                        "tables_with_no_data:22"
+                        "tables_with_no_data:22",
+                        "self_referenced_foreign_keys:0"
                     );
             }
         );

--- a/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/SelfReferencedForeignKeysCheckOnCluster.java
+++ b/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/SelfReferencedForeignKeysCheckOnCluster.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.health.checks.cluster;
+
+import io.github.mfvanek.pg.connection.HighAvailabilityPgConnection;
+import io.github.mfvanek.pg.core.checks.host.SelfReferencedForeignKeysCheckOnHost;
+import io.github.mfvanek.pg.model.constraint.ForeignKey;
+
+/**
+ * Check for self-referenced foreign keys without {@code ON DELETE CASCADE} or {@code ON DELETE SET NULL}
+ * on all hosts in the cluster.
+ *
+ * @author Ivan Vakhrushev
+ * @since 0.41.1
+ */
+public class SelfReferencedForeignKeysCheckOnCluster extends AbstractCheckOnCluster<ForeignKey> {
+
+    /**
+     * Constructs a new instance of {@code SelfReferencedForeignKeysCheckOnCluster}.
+     *
+     * @param haPgConnection the high-availability connection to the PostgreSQL cluster; must not be null
+     */
+    public SelfReferencedForeignKeysCheckOnCluster(final HighAvailabilityPgConnection haPgConnection) {
+        super(haPgConnection, SelfReferencedForeignKeysCheckOnHost::new);
+    }
+}

--- a/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/StandardChecksOnCluster.java
+++ b/pg-index-health/src/main/java/io/github/mfvanek/pg/health/checks/cluster/StandardChecksOnCluster.java
@@ -82,7 +82,8 @@ public final class StandardChecksOnCluster implements Function<HighAvailabilityP
             new ColumnsWithCharTypeCheckOnCluster(haPgConnection),
             new TablesWithInheritanceCheckOnCluster(haPgConnection),
             new ForeignKeysWithNullValuesCheckOnCluster(haPgConnection),
-            new TablesWithNoDataCheckOnCluster(haPgConnection)
+            new TablesWithNoDataCheckOnCluster(haPgConnection),
+            new SelfReferencedForeignKeysCheckOnCluster(haPgConnection)
         );
     }
 }

--- a/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/SelfReferencedForeignKeysCheckOnClusterTest.java
+++ b/pg-index-health/src/test/java/io/github/mfvanek/pg/health/checks/cluster/SelfReferencedForeignKeysCheckOnClusterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health
+ *
+ * This file is a part of "pg-index-health" - an embeddable schema linter for PostgreSQL
+ * that detects common anti-patterns and promotes best practices.
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.pg.health.checks.cluster;
+
+import io.github.mfvanek.pg.core.checks.common.Diagnostic;
+import io.github.mfvanek.pg.core.fixtures.support.DatabaseAwareTestBase;
+import io.github.mfvanek.pg.core.fixtures.support.DatabasePopulator;
+import io.github.mfvanek.pg.health.checks.common.DatabaseCheckOnCluster;
+import io.github.mfvanek.pg.model.constraint.ForeignKey;
+import io.github.mfvanek.pg.model.context.PgContext;
+import io.github.mfvanek.pg.model.predicates.SkipTablesByNamePredicate;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+import static io.github.mfvanek.pg.health.support.AbstractCheckOnClusterAssert.assertThat;
+
+class SelfReferencedForeignKeysCheckOnClusterTest extends DatabaseAwareTestBase {
+
+    private final DatabaseCheckOnCluster<@NonNull ForeignKey> check = new SelfReferencedForeignKeysCheckOnCluster(getHaPgConnection());
+
+    @Test
+    void shouldSatisfyContract() {
+        assertThat(check)
+            .hasType(ForeignKey.class)
+            .hasDiagnostic(Diagnostic.SELF_REFERENCED_FOREIGN_KEYS)
+            .isStatic();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
+    void onDatabaseWithThem(final String schemaName) {
+        executeTestOnDatabase(schemaName, DatabasePopulator::withSelfReferencedForeignKeys, ctx -> {
+            assertThat(check)
+                .executing(ctx)
+                .hasSize(2)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(
+                    ForeignKey.ofNullableColumn(ctx, "bad_self_ref_restrict_table", "bad_self_ref_restrict_table_parent_id_fk", "parent_id"),
+                    ForeignKey.ofNullableColumn(ctx, "bad_self_ref_table", "bad_self_ref_table_parent_id_fk", "parent_id")
+                );
+
+            assertThat(check)
+                .executing(ctx, SkipTablesByNamePredicate.of(ctx, List.of("bad_self_ref_table", "bad_self_ref_restrict_table")))
+                .isEmpty();
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PgContext.DEFAULT_SCHEMA_NAME, "custom"})
+    void shouldWorkWithPartitionedTables(final String schemaName) {
+        executeTestOnDatabase(schemaName, DatabasePopulator::withSelfReferencedForeignKeysInPartitionedTable, ctx -> {
+            assertThat(check)
+                .executing(ctx)
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(
+                    ForeignKey.ofNullableColumn(ctx, "bad_self_ref_partitioned", "bad_self_ref_partitioned_parent_id_fk", "parent_id")
+                );
+        });
+    }
+}

--- a/spring-boot-integration/pg-index-health-test-starter/src/main/java/io/github/mfvanek/pg/spring/DatabaseStructureChecksAutoConfiguration.java
+++ b/spring-boot-integration/pg-index-health-test-starter/src/main/java/io/github/mfvanek/pg/spring/DatabaseStructureChecksAutoConfiguration.java
@@ -24,7 +24,6 @@ import io.github.mfvanek.pg.core.checks.host.DuplicatedForeignKeysCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.DuplicatedIndexesCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysNotCoveredWithIndexCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysWithNullValuesCheckOnHost;
-import io.github.mfvanek.pg.core.checks.host.SelfReferencedForeignKeysCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysWithUnmatchedColumnTypeCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.FunctionsWithoutDescriptionCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.IndexesWithBloatCheckOnHost;
@@ -41,6 +40,7 @@ import io.github.mfvanek.pg.core.checks.host.PossibleObjectNameOverflowCheckOnHo
 import io.github.mfvanek.pg.core.checks.host.PrimaryKeysThatMostLikelyNaturalKeysCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.PrimaryKeysWithSerialTypesCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.PrimaryKeysWithVarcharCheckOnHost;
+import io.github.mfvanek.pg.core.checks.host.SelfReferencedForeignKeysCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.SequenceOverflowCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesNotLinkedToOthersCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWhereAllColumnsNullableExceptPrimaryKeyCheckOnHost;

--- a/spring-boot-integration/pg-index-health-test-starter/src/main/java/io/github/mfvanek/pg/spring/DatabaseStructureChecksAutoConfiguration.java
+++ b/spring-boot-integration/pg-index-health-test-starter/src/main/java/io/github/mfvanek/pg/spring/DatabaseStructureChecksAutoConfiguration.java
@@ -24,6 +24,7 @@ import io.github.mfvanek.pg.core.checks.host.DuplicatedForeignKeysCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.DuplicatedIndexesCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysNotCoveredWithIndexCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysWithNullValuesCheckOnHost;
+import io.github.mfvanek.pg.core.checks.host.SelfReferencedForeignKeysCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysWithUnmatchedColumnTypeCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.FunctionsWithoutDescriptionCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.IndexesWithBloatCheckOnHost;
@@ -356,6 +357,13 @@ public class DatabaseStructureChecksAutoConfiguration {
     @ConditionalOnMissingBean
     public TablesWithNoDataCheckOnHost tablesWithNoDataCheckOnHost(final PgConnection pgConnection) {
         return new TablesWithNoDataCheckOnHost(pgConnection);
+    }
+
+    @Bean
+    @ConditionalOnClass(SelfReferencedForeignKeysCheckOnHost.class)
+    @ConditionalOnMissingBean
+    public SelfReferencedForeignKeysCheckOnHost selfReferencedForeignKeysCheckOnHost(final PgConnection pgConnection) {
+        return new SelfReferencedForeignKeysCheckOnHost(pgConnection);
     }
 
     @Bean

--- a/spring-boot-integration/pg-index-health-test-starter/src/test/java/io/github/mfvanek/pg/spring/AutoConfigurationTestBase.java
+++ b/spring-boot-integration/pg-index-health-test-starter/src/test/java/io/github/mfvanek/pg/spring/AutoConfigurationTestBase.java
@@ -25,6 +25,7 @@ import io.github.mfvanek.pg.core.checks.host.DuplicatedForeignKeysCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.DuplicatedIndexesCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysNotCoveredWithIndexCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysWithNullValuesCheckOnHost;
+import io.github.mfvanek.pg.core.checks.host.SelfReferencedForeignKeysCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysWithUnmatchedColumnTypeCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.FunctionsWithoutDescriptionCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.IndexesWithBloatCheckOnHost;
@@ -164,7 +165,8 @@ abstract class AutoConfigurationTestBase {
             ColumnsWithCharTypeCheckOnHost.class,
             TablesWithInheritanceCheckOnHost.class,
             ForeignKeysWithNullValuesCheckOnHost.class,
-            TablesWithNoDataCheckOnHost.class
+            TablesWithNoDataCheckOnHost.class,
+            SelfReferencedForeignKeysCheckOnHost.class
         );
     }
 }

--- a/spring-boot-integration/pg-index-health-test-starter/src/test/java/io/github/mfvanek/pg/spring/AutoConfigurationTestBase.java
+++ b/spring-boot-integration/pg-index-health-test-starter/src/test/java/io/github/mfvanek/pg/spring/AutoConfigurationTestBase.java
@@ -25,7 +25,6 @@ import io.github.mfvanek.pg.core.checks.host.DuplicatedForeignKeysCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.DuplicatedIndexesCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysNotCoveredWithIndexCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysWithNullValuesCheckOnHost;
-import io.github.mfvanek.pg.core.checks.host.SelfReferencedForeignKeysCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.ForeignKeysWithUnmatchedColumnTypeCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.FunctionsWithoutDescriptionCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.IndexesWithBloatCheckOnHost;
@@ -42,6 +41,7 @@ import io.github.mfvanek.pg.core.checks.host.PossibleObjectNameOverflowCheckOnHo
 import io.github.mfvanek.pg.core.checks.host.PrimaryKeysThatMostLikelyNaturalKeysCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.PrimaryKeysWithSerialTypesCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.PrimaryKeysWithVarcharCheckOnHost;
+import io.github.mfvanek.pg.core.checks.host.SelfReferencedForeignKeysCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.SequenceOverflowCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesNotLinkedToOthersCheckOnHost;
 import io.github.mfvanek.pg.core.checks.host.TablesWhereAllColumnsNullableExceptPrimaryKeyCheckOnHost;


### PR DESCRIPTION
Closes https://github.com/mfvanek/pg-index-health/issues/629

### Common steps

- [x] Read [CONTRIBUTING.md](https://github.com/mfvanek/pg-index-health/blob/master/CONTRIBUTING.md)
- [x] Linked to an issue
- [x] Added a description to PR

### For a database check

- [x] I have updated the [list of checks](https://github.com/mfvanek/pg-index-health/blob/master/doc/available_checks.md)
- [x] I have added the same tests for a check on host and a check on cluster
- [x] The check results are validated with `containsExactly()` and `usingRecursiveFieldByFieldElementComparator()`

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
